### PR TITLE
Update references to old github organization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,9 @@ We welcome patches to the NHS.UK Beta, as long as you follow these guidelines:
 ## Git workflow
 
 - Pull requests must contain a succinct, clear summary of what the user need is driving this feature change
-- Follow our [Git styleguide](https://github.com/nhsalpha/styleguides/blob/master/git.md)
+- Follow our [Git styleguide](https://github.com/nhsuk/styleguides/blob/master/git.md)
 - Make a feature branch
-- Ensure your branch contains logical atomic commits before sending a pull request - follow our [Git styleguide](https://github.com/nhsalpha/styleguides/blob/master/git.md)
+- Ensure your branch contains logical atomic commits before sending a pull request - follow our [Git styleguide](https://github.com/nhsuk/styleguides/blob/master/git.md)
 - Pull requests are automatically tested, where applicable using [Travis CI](https://travis-ci.org/), which will report back on whether the tests still pass on your branch
 - You *may* rebase your branch after feedback if it's to include relevant updates from the master branch. We prefer a rebase here to a merge commit as we prefer a clean and straight history on master with discrete merge commits for features
 
@@ -18,7 +18,7 @@ We welcome patches to the NHS.UK Beta, as long as you follow these guidelines:
 ## Code
 
 - Must be readable with meaningful naming, eg no short hand single character variable names
-- Follow our [styleguides](https://github.com/nhsalpha/styleguides)
+- Follow our [styleguides](https://github.com/nhsuk/styleguides)
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Betahealth
 
-[![Build Status](https://img.shields.io/travis/nhsalpha/betahealth.svg?branch=develop&style=flat-square)](https://travis-ci.org/nhsalpha/betahealth)
-[![dependencies](https://img.shields.io/david/nhsalpha/betahealth.svg?style=flat-square&label=dependencies)](https://david-dm.org/nhsalpha/betahealth)
-[![devDependencies](https://img.shields.io/david/dev/nhsalpha/betahealth.svg?style=flat-square&label=devDependencies)](https://david-dm.org/nhsalpha/betahealth#info=devDependencies)
+[![Build Status](https://img.shields.io/travis/nhsuk/betahealth.svg?branch=develop&style=flat-square)](https://travis-ci.org/nhsuk/betahealth)
+[![dependencies](https://img.shields.io/david/nhsuk/betahealth.svg?style=flat-square&label=dependencies)](https://david-dm.org/nhsuk/betahealth)
+[![devDependencies](https://img.shields.io/david/dev/nhsuk/betahealth.svg?style=flat-square&label=devDependencies)](https://david-dm.org/nhsuk/betahealth#info=devDependencies)
 
 This application is a Node based application that runs on [beta.nhs.uk](http://beta.nhs.uk).
 
@@ -17,7 +17,7 @@ This application is a Node based application that runs on [beta.nhs.uk](http://b
 1. Clone repository:
 
   ```
-  git clone https://github.com/nhsalpha/betahealth
+  git clone https://github.com/nhsuk/betahealth
   ```
 
 2. Install node dependencies:


### PR DESCRIPTION
We've moved the github organization from [github.com/nhsalpha](https://github.com/nhsalpha) to [github.com/nhsuk](https://github.com/nhsuk) so we need to update references to the old repositories within this one.