### PR TITLE
Fix consistency in spacing breakpoints

### DIFF
--- a/assets/stylesheets/components/_section-unit.scss
+++ b/assets/stylesheets/components/_section-unit.scss
@@ -1,7 +1,6 @@
 .section-unit {
-  @include element-padding(vertical);
+  @include element-padding(bottom);
   border-bottom: 1px solid tint($nhs-blue, 80%);
-  padding-top: 0;
 
   &:last-child {
     border: 0;

--- a/assets/stylesheets/environment/tools/mixins/_typography.scss
+++ b/assets/stylesheets/environment/tools/mixins/_typography.scss
@@ -138,7 +138,7 @@
 @mixin element-spacing($position: top) {
   margin-#{$position}: $default-spacing-unit;
 
-  @include media(tablet) {
+  @include media(desktop) {
     margin-#{$position}: $default-spacing-unit * 2;
   }
 }
@@ -159,14 +159,20 @@
   @if $type == full {
     padding: $default-spacing-unit;
 
-    @include media(tablet) {
+    @include media(desktop) {
       padding: $default-spacing-unit * 2;
     }
   } @else if $type == vertical {
     padding: $default-spacing-unit 0;
 
-    @include media(tablet) {
+    @include media(desktop) {
       padding: ($default-spacing-unit * 2) 0;
+    }
+  } @else {
+    padding-#{$type}: $default-spacing-unit;
+
+    @include media(desktop) {
+      padding-#{$type}: $default-spacing-unit * 2;
     }
   }
 }


### PR DESCRIPTION
Top/bottom spacing was changing after 'tablet' but let/right spacing was
changing at 'desktop'. This keeps spacing breaks consistent and changes
spacing from 16px to 32px both at 'desktop'