### PR TITLE
Use Frutiger for some pages

### DIFF
--- a/app/views/_includes/global/head.nunjucks
+++ b/app/views/_includes/global/head.nunjucks
@@ -21,11 +21,11 @@
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="1200">
 
-{% if font == "frutiger" %}
-  <!--[if gt IE 8]><!--><link href="{{ asset_path('assets/stylesheets/nhsuk-frutiger.css') }}" media="screen" rel="stylesheet" type="text/css"><!--<![endif]-->
-  <!--[if IE 6]><link href="{{ asset_path('assets/stylesheets/nhsuk-ie6-frutiger.css') }}" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-  <!--[if IE 7]><link href="{{ asset_path('assets/stylesheets/nhsuk-ie7-frutiger.css') }}" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-  <!--[if IE 8]><link href="{{ asset_path('assets/stylesheets/nhsuk-ie8-frutiger.css') }}" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+{% if font %}
+  <!--[if gt IE 8]><!--><link href="{{ asset_path('assets/stylesheets/nhsuk-' + font + '.css') }}" media="screen" rel="stylesheet" type="text/css"><!--<![endif]-->
+  <!--[if IE 6]><link href="{{ asset_path('assets/stylesheets/nhsuk-ie6-' + font + '.css') }}" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if IE 7]><link href="{{ asset_path('assets/stylesheets/nhsuk-ie7-' + font + '.css') }}" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if IE 8]><link href="{{ asset_path('assets/stylesheets/nhsuk-ie8-' + font + '.css') }}" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
 {% else %}
   <!--[if gt IE 8]><!--><link href="{{ asset_path('assets/stylesheets/nhsuk.css') }}" media="screen" rel="stylesheet" type="text/css"><!--<![endif]-->
   <!--[if IE 6]><link href="{{ asset_path('assets/stylesheets/nhsuk-ie6.css') }}" media="screen" rel="stylesheet" type="text/css" /><![endif]-->

--- a/app/views/_includes/global/head.nunjucks
+++ b/app/views/_includes/global/head.nunjucks
@@ -21,10 +21,17 @@
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="1200">
 
-<!--[if gt IE 8]><!--><link href="{{ asset_path('assets/stylesheets/nhsuk.css') }}" media="screen" rel="stylesheet" type="text/css"><!--<![endif]-->
-<!--[if IE 6]><link href="{{ asset_path('assets/stylesheets/nhsuk-ie6.css') }}" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-<!--[if IE 7]><link href="{{ asset_path('assets/stylesheets/nhsuk-ie7.css') }}" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-<!--[if IE 8]><link href="{{ asset_path('assets/stylesheets/nhsuk-ie8.css') }}" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+{% if font == "frutiger" %}
+  <!--[if gt IE 8]><!--><link href="{{ asset_path('assets/stylesheets/nhsuk-frutiger.css') }}" media="screen" rel="stylesheet" type="text/css"><!--<![endif]-->
+  <!--[if IE 6]><link href="{{ asset_path('assets/stylesheets/nhsuk-ie6-frutiger.css') }}" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if IE 7]><link href="{{ asset_path('assets/stylesheets/nhsuk-ie7-frutiger.css') }}" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if IE 8]><link href="{{ asset_path('assets/stylesheets/nhsuk-ie8-frutiger.css') }}" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+{% else %}
+  <!--[if gt IE 8]><!--><link href="{{ asset_path('assets/stylesheets/nhsuk.css') }}" media="screen" rel="stylesheet" type="text/css"><!--<![endif]-->
+  <!--[if IE 6]><link href="{{ asset_path('assets/stylesheets/nhsuk-ie6.css') }}" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if IE 7]><link href="{{ asset_path('assets/stylesheets/nhsuk-ie7.css') }}" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if IE 8]><link href="{{ asset_path('assets/stylesheets/nhsuk-ie8.css') }}" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+{% endif %}
 
 <link rel="stylesheet" href="{{ asset_path('assets/stylesheets/nhsuk-print.css') }}" media="print" type="text/css">
 

--- a/app/views/fungal-nail-infection.nunjucks
+++ b/app/views/fungal-nail-infection.nunjucks
@@ -1,3 +1,5 @@
+{% set font = "frutiger" %}
+
 {% extends '_layouts/content-simple.nunjucks' %}
 
 {% block local_header %}

--- a/assets/stylesheets/environment/settings/_fonts.scss
+++ b/assets/stylesheets/environment/settings/_fonts.scss
@@ -1,31 +1,38 @@
-@font-face {
-  font-family: "FS Me";
-  src: url("#{$cdn-asset-path}fonts/fsme/FSMeWeb-Light.eot?") format("eot"),
-      url("#{$cdn-asset-path}fonts/fsme/FSMeWeb-Light.woff") format("woff");
-  font-weight: 200;
-  font-style: normal;
-}
+@if $font-family == "Frutiger W01" {
 
-@font-face {
-  font-family: "FS Me";
-  src: url("#{$cdn-asset-path}fonts/fsme/FSMeWeb-Regular.eot?") format("eot"),
-      url("#{$cdn-asset-path}fonts/fsme/FSMeWeb-Regular.woff") format("woff");
-  font-weight: 400;
-  font-style: normal;
-}
+  @import url('https://fast.fonts.net/cssapi/0985eb4d-eec4-488b-baa4-22fe85c5ce32.css');
 
-@font-face {
-  font-family: "FS Me";
-  src: url("#{$cdn-asset-path}fonts/fsme/FSMeWeb-Bold.eot?") format("eot"),
-      url("#{$cdn-asset-path}fonts/fsme/FSMeWeb-Bold.woff") format("woff");
-  font-weight: 600;
-  font-style: bold;
-}
+} @else {
 
-@font-face {
-  font-family: "FS Me";
-  src: url("#{$cdn-asset-path}fonts/fsme/FSMeWeb-Heavy.eot?") format("eot"),
-      url("#{$cdn-asset-path}fonts/fsme/FSMeWeb-Heavy.woff") format("woff");
-  font-weight: 800;
-  font-style: bold;
+  @font-face {
+    font-family: "FS Me";
+    src: url("#{$cdn-asset-path}fonts/fsme/FSMeWeb-Light.eot?") format("eot"),
+        url("#{$cdn-asset-path}fonts/fsme/FSMeWeb-Light.woff") format("woff");
+    font-weight: 200;
+    font-style: normal;
+  }
+
+  @font-face {
+    font-family: "FS Me";
+    src: url("#{$cdn-asset-path}fonts/fsme/FSMeWeb-Regular.eot?") format("eot"),
+        url("#{$cdn-asset-path}fonts/fsme/FSMeWeb-Regular.woff") format("woff");
+    font-weight: 400;
+    font-style: normal;
+  }
+
+  @font-face {
+    font-family: "FS Me";
+    src: url("#{$cdn-asset-path}fonts/fsme/FSMeWeb-Bold.eot?") format("eot"),
+        url("#{$cdn-asset-path}fonts/fsme/FSMeWeb-Bold.woff") format("woff");
+    font-weight: 600;
+    font-style: bold;
+  }
+
+  @font-face {
+    font-family: "FS Me";
+    src: url("#{$cdn-asset-path}fonts/fsme/FSMeWeb-Heavy.eot?") format("eot"),
+        url("#{$cdn-asset-path}fonts/fsme/FSMeWeb-Heavy.woff") format("woff");
+    font-weight: 800;
+    font-style: bold;
+  }
 }

--- a/assets/stylesheets/environment/settings/_globals.scss
+++ b/assets/stylesheets/environment/settings/_globals.scss
@@ -1,4 +1,6 @@
 $is-ie: false !default;
 $mobile-ie6: true !default;
 
+$font-family: "FS Me" !default;
+
 $cdn-asset-path: "/* @echo ASSET_PATH */assets/";

--- a/assets/stylesheets/environment/settings/_typography.scss
+++ b/assets/stylesheets/environment/settings/_typography.scss
@@ -1,4 +1,4 @@
-$nhs-font-stack: "FS Me", Arial, sans-serif;
+$nhs-font-stack: $font-family, Arial, sans-serif;
 $print-font-stack: sans-serif;
 
 $is-print: false !default;

--- a/assets/stylesheets/nhsuk-frutiger.scss
+++ b/assets/stylesheets/nhsuk-frutiger.scss
@@ -1,0 +1,3 @@
+$font-family: "Frutiger W01";
+
+@import "nhsuk";

--- a/assets/stylesheets/nhsuk-ie6-frutiger.scss
+++ b/assets/stylesheets/nhsuk-ie6-frutiger.scss
@@ -1,7 +1,3 @@
-$is-ie: true;
-$ie-version: 6;
-$mobile-ie6: false;
-
 $font-family: "Frutiger W01";
 
-@import "nhsuk";
+@import "nhsuk-ie6";

--- a/assets/stylesheets/nhsuk-ie6-frutiger.scss
+++ b/assets/stylesheets/nhsuk-ie6-frutiger.scss
@@ -1,0 +1,7 @@
+$is-ie: true;
+$ie-version: 6;
+$mobile-ie6: false;
+
+$font-family: "Frutiger W01";
+
+@import "nhsuk";

--- a/assets/stylesheets/nhsuk-ie7-frutiger.scss
+++ b/assets/stylesheets/nhsuk-ie7-frutiger.scss
@@ -1,6 +1,3 @@
-$is-ie: true;
-$ie-version: 7;
-
 $font-family: "Frutiger W01";
 
-@import "nhsuk";
+@import "nhsuk-ie7";

--- a/assets/stylesheets/nhsuk-ie7-frutiger.scss
+++ b/assets/stylesheets/nhsuk-ie7-frutiger.scss
@@ -1,0 +1,6 @@
+$is-ie: true;
+$ie-version: 7;
+
+$font-family: "Frutiger W01";
+
+@import "nhsuk";

--- a/assets/stylesheets/nhsuk-ie8-frutiger.scss
+++ b/assets/stylesheets/nhsuk-ie8-frutiger.scss
@@ -1,6 +1,3 @@
-$is-ie: true;
-$ie-version: 8;
-
 $font-family: "Frutiger W01";
 
-@import "nhsuk";
+@import "nhsuk-ie8";

--- a/assets/stylesheets/nhsuk-ie8-frutiger.scss
+++ b/assets/stylesheets/nhsuk-ie8-frutiger.scss
@@ -1,0 +1,6 @@
+$is-ie: true;
+$ie-version: 8;
+
+$font-family: "Frutiger W01";
+
+@import "nhsuk";

--- a/config/express.js
+++ b/config/express.js
@@ -81,7 +81,12 @@ module.exports = (app, config) => {
           'statse.webtrendslive.com',
           'hm.webtrends.com',
         ],
+        styleSrc: [
+          '\'self\'',
+          'fast.fonts.net',
+        ],
         fontSrc: [
+          'fast.fonts.net',
           config.staticCdn,
         ],
       },
@@ -106,6 +111,7 @@ module.exports = (app, config) => {
       app.use(affinityCookie());
     }
   }
+
 
   // router
   app.use('/', router);

--- a/config/express.js
+++ b/config/express.js
@@ -112,7 +112,6 @@ module.exports = (app, config) => {
     }
   }
 
-
   // router
   app.use('/', router);
 


### PR DESCRIPTION
We want to see how Frutiger compares to FS Me in our beta pages.

Adding in a template variable: `{% set font = "frutiger" %}`
If used, it'll pull in separate versions of `nhsuk.css`, all suffixed `-frutiger`