### PR TITLE
Conditional comment soup

### DIFF
--- a/app/views/_macros/images.nunjucks
+++ b/app/views/_macros/images.nunjucks
@@ -1,0 +1,28 @@
+{% macro image(
+  srcset=[],
+  alt='',
+  analytics
+) %}
+  <!--[if gt IE 7]><!-->
+  <img
+    srcset="
+      {% for src in srcset %}
+        {% set splitSrc = src | split(' ') %}
+        {% if loop.last %}
+          {{ splitSrc[0] }} {{ splitSrc[1] }}
+        {% else %}
+          {{ splitSrc[0] }} {{ splitSrc[1] }},
+        {% endif %}
+      {% endfor %}
+    "
+    alt="{{ alt }}"
+    {% if analytics %}
+      data-analytics="{{ analytics }}"
+    {% endif %}
+    />
+  <!--<![endif]-->
+  <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
+    {% set fallback = srcset[0] | split(' ') %}
+    <img src="{{ fallback[0] }}" alt="{{ alt }}" />
+  <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
+{% endmacro %}

--- a/app/views/fungal-nail-infection.nunjucks
+++ b/app/views/fungal-nail-infection.nunjucks
@@ -1,3 +1,4 @@
+{% import "_macros/images.nunjucks" as images %}
 {% set font = "frutiger" %}
 
 {% extends '_layouts/content-simple.nunjucks' %}
@@ -13,16 +14,14 @@
 
     <figure class="card">
 
-      <!--[if gt IE 7]><!-->
-      <img
-        srcset="{{ asset_path('assets/images/fungal-nail-infection/stage-1-300.jpg') }} 300w,
-                {{ asset_path('assets/images/fungal-nail-infection/stage-1-600.jpg') }} 600w"
-        alt="Fungal infection at the edge of the nail"
-        data-analytics="DCSext.FungalNailImages,Edge" />
-      <!--<![endif]-->
-      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
-        <img src="{{ asset_path('assets/images/fungal-nail-infection/stage-1-300.jpg') }}" alt="Fungal infection at the edge of the nail" />
-      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
+      {{ images.image(
+        srcset=[
+          asset_path("assets/images/fungal-nail-infection/stage-1-300.jpg") + " 300w",
+          asset_path("assets/images/fungal-nail-infection/stage-1-600.jpg") + " 600w"
+        ],
+        alt="Fungal infection at the edge of the nail",
+        analytics="DCSext.FungalNailImages,Edge"
+        ) }}
 
       <figcaption class="card--caption">
         <p>Fungal nail infections usually start at the edge of the nail.</p>
@@ -31,16 +30,14 @@
 
     <figure class="card">
 
-      <!--[if gt IE 7]><!-->
-      <img
-        srcset="{{ asset_path('assets/images/fungal-nail-infection/stage-2-300.jpg') }} 300w,
-                {{ asset_path('assets/images/fungal-nail-infection/stage-2-600.jpg') }} 600w"
-        alt="Infection spread to the middle of the toe"
-        data-analytics="DCSext.FungalNailImages,Spread" />
-      <!--<![endif]-->
-      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
-        <img src="{{ asset_path('assets/images/fungal-nail-infection/stage-2-300.jpg') }}" alt="Infection spread to the middle of the toe" />
-      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
+      {{ images.image(
+        srcset=[
+          asset_path("assets/images/fungal-nail-infection/stage-2-300.jpg") + " 300w",
+          asset_path("assets/images/fungal-nail-infection/stage-2-600.jpg") + " 600w"
+        ],
+        alt="Infection spread to the middle of the toe",
+        analytics="DCSext.FungalNailImages,Spread"
+        ) }}
 
       <figcaption class="card--caption">
         <p>They often then spread to the middle. The nail becomes discoloured and lifts off.</p>
@@ -49,16 +46,15 @@
 
     <figure class="card">
 
-      <!--[if gt IE 7]><!-->
-      <img
-        srcset="{{ asset_path('assets/images/fungal-nail-infection/stage-3-300.jpg') }} 300w,
-                {{ asset_path('assets/images/fungal-nail-infection/stage-3-600.jpg') }} 600w"
-        alt="Brittle nail with pieces missing"
-        data-analytics="DCSext.FungalNailImages,Brittle" />
-      <!--<![endif]-->
-      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
-        <img src="{{ asset_path('assets/images/fungal-nail-infection/stage-3-300.jpg') }}" alt="Brittle nail with pieces missing" />
-      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
+      {{ images.image(
+        srcset=[
+          asset_path("assets/images/fungal-nail-infection/stage-3-300.jpg") + " 300w",
+          asset_path("assets/images/fungal-nail-infection/stage-3-600.jpg") + " 600w"
+        ],
+        alt="Brittle nail with pieces missing",
+        analytics="DCSext.FungalNailImages,Brittle"
+        ) }}
+
       <figcaption class="card--caption">
         <p>The nail becomes brittle and pieces can break off. It can cause pain and swelling in the skin around the nail.</p>
       </figcaption>

--- a/app/views/fungal-nail-infection.nunjucks
+++ b/app/views/fungal-nail-infection.nunjucks
@@ -12,42 +12,53 @@
   <div class="page-section page-section__collapse-bottom">
 
     <figure class="card">
+
+      <!--[if gt IE 7]><!-->
       <img
         srcset="{{ asset_path('assets/images/fungal-nail-infection/stage-1-300.jpg') }} 300w,
                 {{ asset_path('assets/images/fungal-nail-infection/stage-1-600.jpg') }} 600w"
         alt="Fungal infection at the edge of the nail"
         data-analytics="DCSext.FungalNailImages,Edge" />
-      <noscript>
+      <!--<![endif]-->
+      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
         <img src="{{ asset_path('assets/images/fungal-nail-infection/stage-1-300.jpg') }}" alt="Fungal infection at the edge of the nail" />
-      </noscript>
+      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
+
       <figcaption class="card--caption">
         <p>Fungal nail infections usually start at the edge of the nail.</p>
       </figcaption>
     </figure>
 
     <figure class="card">
+
+      <!--[if gt IE 7]><!-->
       <img
         srcset="{{ asset_path('assets/images/fungal-nail-infection/stage-2-300.jpg') }} 300w,
                 {{ asset_path('assets/images/fungal-nail-infection/stage-2-600.jpg') }} 600w"
         alt="Infection spread to the middle of the toe"
         data-analytics="DCSext.FungalNailImages,Spread" />
-      <noscript>
+      <!--<![endif]-->
+      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
         <img src="{{ asset_path('assets/images/fungal-nail-infection/stage-2-300.jpg') }}" alt="Infection spread to the middle of the toe" />
-      </noscript>
+      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
+
       <figcaption class="card--caption">
         <p>They often then spread to the middle. The nail becomes discoloured and lifts off.</p>
       </figcaption>
     </figure>
 
     <figure class="card">
+
+      <!--[if gt IE 7]><!-->
       <img
         srcset="{{ asset_path('assets/images/fungal-nail-infection/stage-3-300.jpg') }} 300w,
                 {{ asset_path('assets/images/fungal-nail-infection/stage-3-600.jpg') }} 600w"
         alt="Brittle nail with pieces missing"
         data-analytics="DCSext.FungalNailImages,Brittle" />
-      <noscript>
+      <!--<![endif]-->
+      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
         <img src="{{ asset_path('assets/images/fungal-nail-infection/stage-3-300.jpg') }}" alt="Brittle nail with pieces missing" />
-      </noscript>
+      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
       <figcaption class="card--caption">
         <p>The nail becomes brittle and pieces can break off. It can cause pain and swelling in the skin around the nail.</p>
       </figcaption>

--- a/app/views/rashes-in-babies-and-children.nunjucks
+++ b/app/views/rashes-in-babies-and-children.nunjucks
@@ -60,6 +60,7 @@
     <article class="section-unit">
       <h3>Fever and red cheeks</h3>
 
+      <!--[if gt IE 7]><!-->
       <img
         srcset="{{ asset_path('assets/images/rashes-in-babies-and-children/fever-and-red-cheeks-400.jpg') }} 400w,
                 {{ asset_path('assets/images/rashes-in-babies-and-children/fever-and-red-cheeks-640.jpg') }} 640w,
@@ -67,9 +68,10 @@
                 {{ asset_path('assets/images/rashes-in-babies-and-children/fever-and-red-cheeks-1280.jpg') }} 1280w"
         alt="A child’s face showing a bright red rash on both cheeks"
         data-analytics="DCSext.RashesChildrenImages,FeverRedCheeks" />
-      <noscript>
+      <!--<![endif]-->
+      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
         <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/fever-and-red-cheeks-400.jpg') }}" alt="A child’s face showing a bright red rash on both cheeks" />
-      </noscript>
+      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
 
       <p>
         A fever with bright red rash on both cheeks can be <a href="http://www.nhs.uk/conditions/slapped-cheek-syndrome/Pages/Introduction.aspx">slapped cheek syndrome.</a> Your child may have a cold and the rash can spread to the body.
@@ -82,6 +84,7 @@
     <article class="section-unit">
       <h3>Small spots and blisters</h3>
 
+      <!--[if gt IE 7]><!-->
       <img
         srcset="{{ asset_path('assets/images/rashes-in-babies-and-children/chicken-pox-400.jpg') }} 400w,
                 {{ asset_path('assets/images/rashes-in-babies-and-children/chicken-pox-640.jpg') }} 640w,
@@ -89,9 +92,10 @@
                 {{ asset_path('assets/images/rashes-in-babies-and-children/chicken-pox-1280.jpg') }} 1280w"
         alt="A baby covered in small spots"
         data-analytics="DCSext.RashesChildrenImages,SmallSpotsBlisters" />
-      <noscript>
+      <!--<![endif]-->
+      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
         <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/chicken-pox-400.jpg') }}" alt="A baby covered in small spots" />
-      </noscript>
+      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
 
       <p>
         <a href="http://www.nhs.uk/conditions/chickenpox/Pages/Introduction.aspx">Chickenpox</a> causes red spots that turn to blisters. They can be itchy. They eventually scab and fall off. Some children have a few spots, while others have them all over their body.
@@ -101,6 +105,7 @@
     <article class="section-unit">
       <h3>Blisters on hands and feet and in the mouth</h3>
 
+      <!--[if gt IE 7]><!-->
       <img
         srcset="{{ asset_path('assets/images/rashes-in-babies-and-children/hand-foot-and-mouth-400.jpg') }} 400w,
                 {{ asset_path('assets/images/rashes-in-babies-and-children/hand-foot-and-mouth-640.jpg') }} 640w,
@@ -108,9 +113,10 @@
                 {{ asset_path('assets/images/rashes-in-babies-and-children/hand-foot-and-mouth-1280.jpg') }} 1280w"
         alt="Blisters on the small finger on a hand"
         data-analytics="DCSext.RashesChildrenImages,BlistersOnHands" />
-      <noscript>
+      <!--<![endif]-->
+      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
         <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/fever-and-red-cheeks-400.jpg') }}" alt="Blisters on the small finger on a hand" />
-      </noscript>
+      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
 
       <p>
         A common childhood illness that causes blisters on the hands and feet and ulcers on the tongue, is <a href="http://www.nhs.uk/conditions/hand-foot-and-mouth-disease/Pages/Introduction.aspx">hand, foot and mouth disease.</a> It also causes fever and your child may have a cold.
@@ -123,6 +129,7 @@
     <article class="section-unit">
       <h3>Pink-red rash</h3>
 
+      <!--[if gt IE 7]><!-->
       <img
         srcset="{{ asset_path('assets/images/rashes-in-babies-and-children/scarlet-fever-400.jpg') }} 400w,
                 {{ asset_path('assets/images/rashes-in-babies-and-children/scarlet-fever-640.jpg') }} 640w,
@@ -130,9 +137,10 @@
                 {{ asset_path('assets/images/rashes-in-babies-and-children/scarlet-fever-1280.jpg') }} 1280w"
         alt="A child’s chest and shoulders covered in a pink-red rash"
         data-analytics="DCSext.RashesChildrenImages,PinkRedRash" />
-      <noscript>
+      <!--<![endif]-->
+      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
         <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/scarlet-fever-400.jpg') }}" alt="A child’s chest and shoulders covered in a pink-red rash" />
-      </noscript>
+      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
 
       <p>
         <a href="http://www.nhs.uk/Conditions/Scarlet-fever/Pages/Introduction.aspx">Scarlet fever</a> causes a pink-red rash, which feels like sandpaper and looks like sunburn.
@@ -152,6 +160,7 @@
     <article class="section-unit">
       <h3>Rash caused by heat</h3>
 
+      <!--[if gt IE 7]><!-->
       <img
         srcset="{{ asset_path('assets/images/rashes-in-babies-and-children/heat-rash-400.jpg') }} 400w,
                 {{ asset_path('assets/images/rashes-in-babies-and-children/heat-rash-640.jpg') }} 640w,
@@ -159,9 +168,10 @@
                 {{ asset_path('assets/images/rashes-in-babies-and-children/heat-rash-1280.jpg') }} 1280w"
         alt="A child’s back showing a heat rash under a pulled up t-shirt"
         data-analytics="DCSext.RashesChildrenImages,RashesHeat" />
-      <noscript>
+      <!--<![endif]-->
+      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
         <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/heat-rash-400.jpg') }}" alt="A child’s back showing a heat rash under a pulled up t-shirt" />
-      </noscript>
+      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
 
       <p>
         Heat and sweat can cause small, red spots known as prickly heat or heat rash. It itches so you may notice your baby scratching.
@@ -174,6 +184,7 @@
     <article class="section-unit">
       <h3>Red scaly skin or cracked skin</h3>
 
+      <!--[if gt IE 7]><!-->
       <img
         srcset="{{ asset_path('assets/images/rashes-in-babies-and-children/eczma-400.jpg') }} 400w,
                 {{ asset_path('assets/images/rashes-in-babies-and-children/eczma-640.jpg') }} 640w,
@@ -181,9 +192,10 @@
                 {{ asset_path('assets/images/rashes-in-babies-and-children/eczma-1280.jpg') }} 1280w"
         alt="Back of a child’s knees showing red, cracked skin"
         data-analytics="DCSext.RashesChildrenImages,ScalyCrackedSkin" />
-      <noscript>
+      <!--<![endif]-->
+      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
         <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/eczma-400.jpg') }}" alt="Back of a child’s knees showing red, cracked skin" />
-      </noscript>
+      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
 
       <p>
         Skin that's itchy, red, dry and cracked may be <a href="http://www.nhs.uk/conditions/Eczema-(atopic)/Pages/Introduction.aspx">eczema.</a> It’s common behind the knees and elbows and the neck, but can appear anywhere.
@@ -196,6 +208,7 @@
     <article class="section-unit">
       <h3>Raised itchy spots</h3>
 
+      <!--[if gt IE 7]><!-->
       <img
         srcset="{{ asset_path('assets/images/rashes-in-babies-and-children/hives-400.jpg') }} 400w,
                 {{ asset_path('assets/images/rashes-in-babies-and-children/hives-640.jpg') }} 640w,
@@ -203,9 +216,10 @@
                 {{ asset_path('assets/images/rashes-in-babies-and-children/hives-1280.jpg') }} 1280w"
         alt="Side of a child’s knee showing hives"
         data-analytics="DCSext.RashesChildrenImages,RaisedItchySpots" />
-      <noscript>
+      <!--<![endif]-->
+      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
         <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/hives-400.jpg') }}" alt="Side of a child’s knee showing hives" />
-      </noscript>
+      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
 
       <p>
         A raised, red, itchy rash (hives) can appear as an allergic reaction to things like stings, medicines or food.
@@ -224,6 +238,7 @@
     <article class="section-unit">
       <h3>Itchy, round rash</h3>
 
+      <!--[if gt IE 7]><!-->
       <img
         srcset="{{ asset_path('assets/images/rashes-in-babies-and-children/ringworm-400.jpg') }} 400w,
                 {{ asset_path('assets/images/rashes-in-babies-and-children/ringworm-640.jpg') }} 640w,
@@ -231,9 +246,10 @@
                 {{ asset_path('assets/images/rashes-in-babies-and-children/ringworm-1280.jpg') }} 1280w"
         alt="Ringworm rash on skin"
         data-analytics="DCSext.RashesChildrenImages,ItchyRoundRash" />
-      <noscript>
+      <!--<![endif]-->
+      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
         <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/ringworm-400.jpg') }}" alt="Ringworm rash on skin" />
-      </noscript>
+      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
 
       <p>
         An itchy, ring-like rash can be <a href="http://www.nhs.uk/Conditions/Ringworm/Pages/Introduction.aspx">ringworm.</a>
@@ -253,6 +269,7 @@
     <article class="section-unit">
       <h3>White spots in babies</h3>
 
+      <!--[if gt IE 7]><!-->
       <img
         srcset="{{ asset_path('assets/images/rashes-in-babies-and-children/milia-400.jpg') }} 400w,
                 {{ asset_path('assets/images/rashes-in-babies-and-children/milia-640.jpg') }} 640w,
@@ -260,9 +277,10 @@
                 {{ asset_path('assets/images/rashes-in-babies-and-children/milia-1280.jpg') }} 1280w"
         alt="Close-up of a baby’s nose showing small white spots"
         data-analytics="DCSext.RashesChildrenImages,WhiteSpotsBabies" />
-      <noscript>
+      <!--<![endif]-->
+      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
         <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/milia-400.jpg') }}" alt="Close-up of a baby’s nose showing small white spots" />
-      </noscript>
+      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
 
       <p>
         Small white spots <a href="http://patient.info/health/milia-leaflet">(milia)</a> often appear on a baby’s face when they are a few days old. They usually clear up within a few weeks and don’t need treatment.
@@ -272,6 +290,7 @@
     <article class="section-unit">
       <h3>Red, yellow and white spots in babies</h3>
 
+      <!--[if gt IE 7]><!-->
       <img
         srcset="{{ asset_path('assets/images/rashes-in-babies-and-children/erythema-400.jpg') }} 400w,
                 {{ asset_path('assets/images/rashes-in-babies-and-children/erythema-640.jpg') }} 640w,
@@ -279,9 +298,10 @@
                 {{ asset_path('assets/images/rashes-in-babies-and-children/erythema-1280.jpg') }} 1280w"
         alt="Baby’s head and shoulders showing raised spots"
         data-analytics="DCSext.RashesChildrenImages,RedYellowWhiteSpots" />
-      <noscript>
+      <!--<![endif]-->
+      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
         <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/erythema-400.jpg') }}" alt="Baby’s head and shoulders showing raised spots" />
-      </noscript>
+      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
 
       <p>
         Raised red, yellow and white spots (erythema toxicum) can appear on babies when they’re born. They usually appear on the face, the body and the upper arms and thighs.
@@ -297,6 +317,7 @@
     <article class="section-unit">
       <h3>Pink or skin-coloured spots</h3>
 
+      <!--[if gt IE 7]><!-->
       <img
         srcset="{{ asset_path('assets/images/rashes-in-babies-and-children/molluscum-400.jpg') }} 400w,
                 {{ asset_path('assets/images/rashes-in-babies-and-children/molluscum-640.jpg') }} 640w,
@@ -304,9 +325,10 @@
                 {{ asset_path('assets/images/rashes-in-babies-and-children/molluscum-1280.jpg') }} 1280w"
         alt="Small, pink raised spots on skin"
         data-analytics="DCSext.RashesChildrenImages,PinkSkinColoured" />
-      <noscript>
+      <!--<![endif]-->
+      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
         <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/molluscum-400.jpg') }}" alt="Small, pink raised spots on skin" />
-      </noscript>
+      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
 
       <p>
         Small, firm, raised spots that can appear anywhere on the body are common in children and known as <a href="http://www.nhs.uk/conditions/molluscum-contagiosum/pages/introduction.aspx">molluscum contagiosum.</a>
@@ -319,6 +341,7 @@
     <article class="section-unit">
       <h3>Red patches on a baby’s bottom</h3>
 
+      <!--[if gt IE 7]><!-->
       <img
         srcset="{{ asset_path('assets/images/rashes-in-babies-and-children/nappy-400.jpg') }} 400w,
                 {{ asset_path('assets/images/rashes-in-babies-and-children/nappy-640.jpg') }} 640w,
@@ -326,9 +349,10 @@
                 {{ asset_path('assets/images/rashes-in-babies-and-children/nappy-1280.jpg') }} 1280w"
         alt="Red patch on a baby’s bottom"
         data-analytics="DCSext.RashesChildrenImages,RedPatches" />
-      <noscript>
+      <!--<![endif]-->
+      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
         <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/nappy-400.jpg') }}" alt="Red patch on a baby’s bottom" />
-      </noscript>
+      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
 
       <p>
         <a href="http://www.nhs.uk/Conditions/pregnancy-and-baby/Pages/Nappy-rash.aspx">Nappy rash</a> can be red patches on your baby’s bottom, or the whole nappy area. The skin may look sore and feel hot. There may be spots or blisters. It can make you child feel uncomfortable or distressed.

--- a/app/views/rashes-in-babies-and-children.nunjucks
+++ b/app/views/rashes-in-babies-and-children.nunjucks
@@ -1,3 +1,5 @@
+{% import "_macros/images.nunjucks" as images %}
+
 {% extends '_layouts/content-sidebar-first.nunjucks' %}
 
 {% block local_header %}
@@ -60,18 +62,16 @@
     <article class="section-unit">
       <h3>Fever and red cheeks</h3>
 
-      <!--[if gt IE 7]><!-->
-      <img
-        srcset="{{ asset_path('assets/images/rashes-in-babies-and-children/fever-and-red-cheeks-400.jpg') }} 400w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/fever-and-red-cheeks-640.jpg') }} 640w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/fever-and-red-cheeks-800.jpg') }} 800w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/fever-and-red-cheeks-1280.jpg') }} 1280w"
-        alt="A child’s face showing a bright red rash on both cheeks"
-        data-analytics="DCSext.RashesChildrenImages,FeverRedCheeks" />
-      <!--<![endif]-->
-      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
-        <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/fever-and-red-cheeks-400.jpg') }}" alt="A child’s face showing a bright red rash on both cheeks" />
-      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
+      {{ images.image(
+        srcset=[
+          asset_path("assets/images/rashes-in-babies-and-children/fever-and-red-cheeks-400.jpg") + " 400w",
+          asset_path("assets/images/rashes-in-babies-and-children/fever-and-red-cheeks-640.jpg") + " 640w",
+          asset_path("assets/images/rashes-in-babies-and-children/fever-and-red-cheeks-800.jpg") + " 800w",
+          asset_path("assets/images/rashes-in-babies-and-children/fever-and-red-cheeks-1280.jpg") + " 1280w"
+        ],
+        alt="A child’s face showing a bright red rash on both cheeks",
+        analytics="DCSext.RashesChildrenImages,FeverRedCheeks"
+        ) }}
 
       <p>
         A fever with bright red rash on both cheeks can be <a href="http://www.nhs.uk/conditions/slapped-cheek-syndrome/Pages/Introduction.aspx">slapped cheek syndrome.</a> Your child may have a cold and the rash can spread to the body.
@@ -84,18 +84,16 @@
     <article class="section-unit">
       <h3>Small spots and blisters</h3>
 
-      <!--[if gt IE 7]><!-->
-      <img
-        srcset="{{ asset_path('assets/images/rashes-in-babies-and-children/chicken-pox-400.jpg') }} 400w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/chicken-pox-640.jpg') }} 640w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/chicken-pox-800.jpg') }} 800w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/chicken-pox-1280.jpg') }} 1280w"
-        alt="A baby covered in small spots"
-        data-analytics="DCSext.RashesChildrenImages,SmallSpotsBlisters" />
-      <!--<![endif]-->
-      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
-        <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/chicken-pox-400.jpg') }}" alt="A baby covered in small spots" />
-      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
+      {{ images.image(
+        srcset=[
+          asset_path("assets/images/rashes-in-babies-and-children/chicken-pox-400.jpg") + " 400w",
+          asset_path("assets/images/rashes-in-babies-and-children/chicken-pox-640.jpg") + " 640w",
+          asset_path("assets/images/rashes-in-babies-and-children/chicken-pox-800.jpg") + " 800w",
+          asset_path("assets/images/rashes-in-babies-and-children/chicken-pox-1280.jpg") + " 1280w"
+        ],
+        alt="A baby covered in small spots",
+        analytics="DCSext.RashesChildrenImages,SmallSpotsBlisters"
+        ) }}
 
       <p>
         <a href="http://www.nhs.uk/conditions/chickenpox/Pages/Introduction.aspx">Chickenpox</a> causes red spots that turn to blisters. They can be itchy. They eventually scab and fall off. Some children have a few spots, while others have them all over their body.
@@ -105,18 +103,16 @@
     <article class="section-unit">
       <h3>Blisters on hands and feet and in the mouth</h3>
 
-      <!--[if gt IE 7]><!-->
-      <img
-        srcset="{{ asset_path('assets/images/rashes-in-babies-and-children/hand-foot-and-mouth-400.jpg') }} 400w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/hand-foot-and-mouth-640.jpg') }} 640w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/hand-foot-and-mouth-800.jpg') }} 800w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/hand-foot-and-mouth-1280.jpg') }} 1280w"
-        alt="Blisters on the small finger on a hand"
-        data-analytics="DCSext.RashesChildrenImages,BlistersOnHands" />
-      <!--<![endif]-->
-      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
-        <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/fever-and-red-cheeks-400.jpg') }}" alt="Blisters on the small finger on a hand" />
-      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
+      {{ images.image(
+        srcset=[
+          asset_path("assets/images/rashes-in-babies-and-children/hand-foot-and-mouth-400.jpg") + " 400w",
+          asset_path("assets/images/rashes-in-babies-and-children/hand-foot-and-mouth-640.jpg") + " 640w",
+          asset_path("assets/images/rashes-in-babies-and-children/hand-foot-and-mouth-800.jpg") + " 800w",
+          asset_path("assets/images/rashes-in-babies-and-children/hand-foot-and-mouth-1280.jpg") + " 1280w"
+        ],
+        alt="Blisters on the small finger on a hand",
+        analytics="DCSext.RashesChildrenImages,BlistersOnHands"
+        ) }}
 
       <p>
         A common childhood illness that causes blisters on the hands and feet and ulcers on the tongue, is <a href="http://www.nhs.uk/conditions/hand-foot-and-mouth-disease/Pages/Introduction.aspx">hand, foot and mouth disease.</a> It also causes fever and your child may have a cold.
@@ -129,18 +125,16 @@
     <article class="section-unit">
       <h3>Pink-red rash</h3>
 
-      <!--[if gt IE 7]><!-->
-      <img
-        srcset="{{ asset_path('assets/images/rashes-in-babies-and-children/scarlet-fever-400.jpg') }} 400w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/scarlet-fever-640.jpg') }} 640w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/scarlet-fever-800.jpg') }} 800w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/scarlet-fever-1280.jpg') }} 1280w"
-        alt="A child’s chest and shoulders covered in a pink-red rash"
-        data-analytics="DCSext.RashesChildrenImages,PinkRedRash" />
-      <!--<![endif]-->
-      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
-        <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/scarlet-fever-400.jpg') }}" alt="A child’s chest and shoulders covered in a pink-red rash" />
-      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
+      {{ images.image(
+        srcset=[
+          asset_path("assets/images/rashes-in-babies-and-children/scarlet-fever-400.jpg") + " 400w",
+          asset_path("assets/images/rashes-in-babies-and-children/scarlet-fever-640.jpg") + " 640w",
+          asset_path("assets/images/rashes-in-babies-and-children/scarlet-fever-800.jpg") + " 800w",
+          asset_path("assets/images/rashes-in-babies-and-children/scarlet-fever-1280.jpg") + " 1280w"
+        ],
+        alt="A child’s chest and shoulders covered in a pink-red rash",
+        analytics="DCSext.RashesChildrenImages,PinkRedRash"
+        ) }}
 
       <p>
         <a href="http://www.nhs.uk/Conditions/Scarlet-fever/Pages/Introduction.aspx">Scarlet fever</a> causes a pink-red rash, which feels like sandpaper and looks like sunburn.
@@ -160,18 +154,16 @@
     <article class="section-unit">
       <h3>Rash caused by heat</h3>
 
-      <!--[if gt IE 7]><!-->
-      <img
-        srcset="{{ asset_path('assets/images/rashes-in-babies-and-children/heat-rash-400.jpg') }} 400w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/heat-rash-640.jpg') }} 640w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/heat-rash-800.jpg') }} 800w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/heat-rash-1280.jpg') }} 1280w"
-        alt="A child’s back showing a heat rash under a pulled up t-shirt"
-        data-analytics="DCSext.RashesChildrenImages,RashesHeat" />
-      <!--<![endif]-->
-      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
-        <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/heat-rash-400.jpg') }}" alt="A child’s back showing a heat rash under a pulled up t-shirt" />
-      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
+      {{ images.image(
+        srcset=[
+          asset_path("assets/images/rashes-in-babies-and-children/heat-rash-400.jpg") + " 400w",
+          asset_path("assets/images/rashes-in-babies-and-children/heat-rash-640.jpg") + " 640w",
+          asset_path("assets/images/rashes-in-babies-and-children/heat-rash-800.jpg") + " 800w",
+          asset_path("assets/images/rashes-in-babies-and-children/heat-rash-1280.jpg") + " 1280w"
+        ],
+        alt="A child’s back showing a heat rash under a pulled up t-shirt",
+        analytics="DCSext.RashesChildrenImages,RashesHeat"
+        ) }}
 
       <p>
         Heat and sweat can cause small, red spots known as prickly heat or heat rash. It itches so you may notice your baby scratching.
@@ -184,18 +176,16 @@
     <article class="section-unit">
       <h3>Red scaly skin or cracked skin</h3>
 
-      <!--[if gt IE 7]><!-->
-      <img
-        srcset="{{ asset_path('assets/images/rashes-in-babies-and-children/eczma-400.jpg') }} 400w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/eczma-640.jpg') }} 640w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/eczma-800.jpg') }} 800w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/eczma-1280.jpg') }} 1280w"
-        alt="Back of a child’s knees showing red, cracked skin"
-        data-analytics="DCSext.RashesChildrenImages,ScalyCrackedSkin" />
-      <!--<![endif]-->
-      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
-        <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/eczma-400.jpg') }}" alt="Back of a child’s knees showing red, cracked skin" />
-      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
+      {{ images.image(
+        srcset=[
+          asset_path("assets/images/rashes-in-babies-and-children/eczma-400.jpg") + " 400w",
+          asset_path("assets/images/rashes-in-babies-and-children/eczma-640.jpg") + " 640w",
+          asset_path("assets/images/rashes-in-babies-and-children/eczma-800.jpg") + " 800w",
+          asset_path("assets/images/rashes-in-babies-and-children/eczma-1280.jpg") + " 1280w"
+        ],
+        alt="Back of a child’s knees showing red, cracked skin",
+        analytics="DCSext.RashesChildrenImages,ScalyCrackedSkin"
+        ) }}
 
       <p>
         Skin that's itchy, red, dry and cracked may be <a href="http://www.nhs.uk/conditions/Eczema-(atopic)/Pages/Introduction.aspx">eczema.</a> It’s common behind the knees and elbows and the neck, but can appear anywhere.
@@ -208,18 +198,16 @@
     <article class="section-unit">
       <h3>Raised itchy spots</h3>
 
-      <!--[if gt IE 7]><!-->
-      <img
-        srcset="{{ asset_path('assets/images/rashes-in-babies-and-children/hives-400.jpg') }} 400w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/hives-640.jpg') }} 640w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/hives-800.jpg') }} 800w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/hives-1280.jpg') }} 1280w"
-        alt="Side of a child’s knee showing hives"
-        data-analytics="DCSext.RashesChildrenImages,RaisedItchySpots" />
-      <!--<![endif]-->
-      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
-        <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/hives-400.jpg') }}" alt="Side of a child’s knee showing hives" />
-      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
+      {{ images.image(
+        srcset=[
+          asset_path("assets/images/rashes-in-babies-and-children/hives-400.jpg") + " 400w",
+          asset_path("assets/images/rashes-in-babies-and-children/hives-640.jpg") + " 640w",
+          asset_path("assets/images/rashes-in-babies-and-children/hives-800.jpg") + " 800w",
+          asset_path("assets/images/rashes-in-babies-and-children/hives-1280.jpg") + " 1280w"
+        ],
+        alt="Side of a child’s knee showing hives",
+        analytics="DCSext.RashesChildrenImages,RaisedItchySpots"
+        ) }}
 
       <p>
         A raised, red, itchy rash (hives) can appear as an allergic reaction to things like stings, medicines or food.
@@ -238,18 +226,16 @@
     <article class="section-unit">
       <h3>Itchy, round rash</h3>
 
-      <!--[if gt IE 7]><!-->
-      <img
-        srcset="{{ asset_path('assets/images/rashes-in-babies-and-children/ringworm-400.jpg') }} 400w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/ringworm-640.jpg') }} 640w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/ringworm-800.jpg') }} 800w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/ringworm-1280.jpg') }} 1280w"
-        alt="Ringworm rash on skin"
-        data-analytics="DCSext.RashesChildrenImages,ItchyRoundRash" />
-      <!--<![endif]-->
-      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
-        <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/ringworm-400.jpg') }}" alt="Ringworm rash on skin" />
-      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
+      {{ images.image(
+        srcset=[
+          asset_path("assets/images/rashes-in-babies-and-children/ringworm-400.jpg") + " 400w",
+          asset_path("assets/images/rashes-in-babies-and-children/ringworm-640.jpg") + " 640w",
+          asset_path("assets/images/rashes-in-babies-and-children/ringworm-800.jpg") + " 800w",
+          asset_path("assets/images/rashes-in-babies-and-children/ringworm-1280.jpg") + " 1280w"
+        ],
+        alt="Ringworm rash on skin",
+        analytics="DCSext.RashesChildrenImages,ItchyRoundRash"
+        ) }}
 
       <p>
         An itchy, ring-like rash can be <a href="http://www.nhs.uk/Conditions/Ringworm/Pages/Introduction.aspx">ringworm.</a>
@@ -269,18 +255,16 @@
     <article class="section-unit">
       <h3>White spots in babies</h3>
 
-      <!--[if gt IE 7]><!-->
-      <img
-        srcset="{{ asset_path('assets/images/rashes-in-babies-and-children/milia-400.jpg') }} 400w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/milia-640.jpg') }} 640w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/milia-800.jpg') }} 800w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/milia-1280.jpg') }} 1280w"
-        alt="Close-up of a baby’s nose showing small white spots"
-        data-analytics="DCSext.RashesChildrenImages,WhiteSpotsBabies" />
-      <!--<![endif]-->
-      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
-        <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/milia-400.jpg') }}" alt="Close-up of a baby’s nose showing small white spots" />
-      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
+      {{ images.image(
+        srcset=[
+          asset_path("assets/images/rashes-in-babies-and-children/milia-400.jpg") + " 400w",
+          asset_path("assets/images/rashes-in-babies-and-children/milia-640.jpg") + " 640w",
+          asset_path("assets/images/rashes-in-babies-and-children/milia-800.jpg") + " 800w",
+          asset_path("assets/images/rashes-in-babies-and-children/milia-1280.jpg") + " 1280w"
+        ],
+        alt="Close-up of a baby’s nose showing small white spots",
+        analytics="DCSext.RashesChildrenImages,WhiteSpotsBabies"
+        ) }}
 
       <p>
         Small white spots <a href="http://patient.info/health/milia-leaflet">(milia)</a> often appear on a baby’s face when they are a few days old. They usually clear up within a few weeks and don’t need treatment.
@@ -290,18 +274,16 @@
     <article class="section-unit">
       <h3>Red, yellow and white spots in babies</h3>
 
-      <!--[if gt IE 7]><!-->
-      <img
-        srcset="{{ asset_path('assets/images/rashes-in-babies-and-children/erythema-400.jpg') }} 400w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/erythema-640.jpg') }} 640w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/erythema-800.jpg') }} 800w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/erythema-1280.jpg') }} 1280w"
-        alt="Baby’s head and shoulders showing raised spots"
-        data-analytics="DCSext.RashesChildrenImages,RedYellowWhiteSpots" />
-      <!--<![endif]-->
-      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
-        <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/erythema-400.jpg') }}" alt="Baby’s head and shoulders showing raised spots" />
-      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
+      {{ images.image(
+        srcset=[
+          asset_path("assets/images/rashes-in-babies-and-children/erythema-400.jpg") + " 400w",
+          asset_path("assets/images/rashes-in-babies-and-children/erythema-640.jpg") + " 640w",
+          asset_path("assets/images/rashes-in-babies-and-children/erythema-800.jpg") + " 800w",
+          asset_path("assets/images/rashes-in-babies-and-children/erythema-1280.jpg") + " 1280w"
+        ],
+        alt="Baby’s head and shoulders showing raised spots",
+        analytics="DCSext.RashesChildrenImages,RedYellowWhiteSpots"
+        ) }}
 
       <p>
         Raised red, yellow and white spots (erythema toxicum) can appear on babies when they’re born. They usually appear on the face, the body and the upper arms and thighs.
@@ -317,18 +299,16 @@
     <article class="section-unit">
       <h3>Pink or skin-coloured spots</h3>
 
-      <!--[if gt IE 7]><!-->
-      <img
-        srcset="{{ asset_path('assets/images/rashes-in-babies-and-children/molluscum-400.jpg') }} 400w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/molluscum-640.jpg') }} 640w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/molluscum-800.jpg') }} 800w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/molluscum-1280.jpg') }} 1280w"
-        alt="Small, pink raised spots on skin"
-        data-analytics="DCSext.RashesChildrenImages,PinkSkinColoured" />
-      <!--<![endif]-->
-      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
-        <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/molluscum-400.jpg') }}" alt="Small, pink raised spots on skin" />
-      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
+      {{ images.image(
+        srcset=[
+          asset_path("assets/images/rashes-in-babies-and-children/molluscum-400.jpg") + " 400w",
+          asset_path("assets/images/rashes-in-babies-and-children/molluscum-640.jpg") + " 640w",
+          asset_path("assets/images/rashes-in-babies-and-children/molluscum-800.jpg") + " 800w",
+          asset_path("assets/images/rashes-in-babies-and-children/molluscum-1280.jpg") + " 1280w"
+        ],
+        alt="Small, pink raised spots on skin",
+        analytics="DCSext.RashesChildrenImages,PinkSkinColoured"
+        ) }}
 
       <p>
         Small, firm, raised spots that can appear anywhere on the body are common in children and known as <a href="http://www.nhs.uk/conditions/molluscum-contagiosum/pages/introduction.aspx">molluscum contagiosum.</a>
@@ -341,18 +321,16 @@
     <article class="section-unit">
       <h3>Red patches on a baby’s bottom</h3>
 
-      <!--[if gt IE 7]><!-->
-      <img
-        srcset="{{ asset_path('assets/images/rashes-in-babies-and-children/nappy-400.jpg') }} 400w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/nappy-640.jpg') }} 640w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/nappy-800.jpg') }} 800w,
-                {{ asset_path('assets/images/rashes-in-babies-and-children/nappy-1280.jpg') }} 1280w"
-        alt="Red patch on a baby’s bottom"
-        data-analytics="DCSext.RashesChildrenImages,RedPatches" />
-      <!--<![endif]-->
-      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
-        <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/nappy-400.jpg') }}" alt="Red patch on a baby’s bottom" />
-      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
+      {{ images.image(
+        srcset=[
+          asset_path("assets/images/rashes-in-babies-and-children/nappy-400.jpg") + " 400w",
+          asset_path("assets/images/rashes-in-babies-and-children/nappy-640.jpg") + " 640w",
+          asset_path("assets/images/rashes-in-babies-and-children/nappy-800.jpg") + " 800w",
+          asset_path("assets/images/rashes-in-babies-and-children/nappy-1280.jpg") + " 1280w"
+        ],
+        alt="Red patch on a baby’s bottom",
+        analytics="DCSext.RashesChildrenImages,RedPatches"
+        ) }}
 
       <p>
         <a href="http://www.nhs.uk/Conditions/pregnancy-and-baby/Pages/Nappy-rash.aspx">Nappy rash</a> can be red patches on your baby’s bottom, or the whole nappy area. The skin may look sore and feel hot. There may be spots or blisters. It can make you child feel uncomfortable or distressed.

--- a/config/express.js
+++ b/config/express.js
@@ -9,7 +9,6 @@ const enforce = require('express-sslify');
 const churchill = require('churchill');
 const validator = require('express-validator');
 const csrf = require('csurf');
-
 const logger = require('../lib/logger');
 const checkSecure = require('../app/middleware/check-secure');
 const locals = require('../app/middleware/locals');
@@ -22,9 +21,12 @@ const router = require('./routes');
 module.exports = (app, config) => {
   app.set('views', `${config.root}/app/views`);
   app.set('view engine', 'nunjucks');
-  nunjucks.configure(`${config.root}/app/views`, {
+  const env = nunjucks.configure(`${config.root}/app/views`, {
     autoescape: true,
     express: app,
+  });
+  env.addFilter('split', (str, seperator) => {
+    return str.split(seperator);
   });
 
   if (!config.ci) {


### PR DESCRIPTION
Looking at a way to allow older IE (7 and 6) to fall back to simple image display.

While we’re not "officially" supporting these browsers, the markup pattern we're using means that a js-enabled browser will *not* display an image. This feels wrong to me, and somewhat against the principles of progressive enhancement.

*We're still going to have this issue with really really really old / non-evergreen browsers*
Think Netscape, IE5 and lower, you name it. I suggest we keep an eye on traffic and test accordingly. 

As a note, we've had 6 IE7 visitors since beta launch, none lower than that.

Onto the code:

```
      <!--[if gt IE 7]><!-->
      <img
        srcset="fever-and-red-cheeks-400.jpg 400w,
                fever-and-red-cheeks-640.jpg 640w,
                fever-and-red-cheeks-800.jpg 800w,
                fever-and-red-cheeks-1280.jpg 1280w"
        alt="A child’s face showing a bright red rash on both cheeks" />
      <!--<![endif]-->
      <!--[if gt IE 7]><!--><noscript><!--<![endif]-->
        <img src="fever-and-red-cheeks-400.jpg" alt="A child’s face showing a bright red rash on both cheeks" />
      <!--[if gt IE 7]><!--></noscript><!--<![endif]-->
```

This smells a bit I know, but I think there's enough supporting tech to go with this "sort of standards markup rather than js" approach?

Pretty quickly I think we'd abstract this into a macro or similar that gets fed something a bit like this:
```
      files: [
        fever-and-red-cheeks-400.jpg,
        fever-and-red-cheeks-640.jpg,
        fever-and-red-cheeks-800.jpg,
        fever-and-red-cheeks-1280.jpg
      ],
      widths: [
        400,
        640,
        800,
        1280
      ],
      alt: 'A child’s face showing a bright red rash on both cheeks',
      webtrends: 'somekindofusefulstring'
```
... you get the idea. Just abstract it a little bit.

Anyway. Thoughts?