### PR TITLE
Extract webtrends onclick tracking to separate module

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,8 @@
   "rules": {
     "arrow-body-style": ["error", "always"],
     "import/no-extraneous-dependencies": 0,
-    "no-prototype-builtins": 0
+    "no-prototype-builtins": 0,
+    "no-underscore-dangle": 0,
+    "prefer-spread": 0
   }
 }

--- a/app/views/_includes/feedback-form.nunjucks
+++ b/app/views/_includes/feedback-form.nunjucks
@@ -33,8 +33,8 @@
           </div>
         </div>
 
-        <button type="submit" class="button" onclick="dcsMultiTrack('DCSext.GeneralLinks','SendFeedback','WT.dl','121')">Send feedback</button>
-        <button type="reset" class="button button__cancel" onclick="dcsMultiTrack('DCSext.GeneralLinks','CancelFeedback','WT.dl','121')">Cancel</button>
+        <button type="submit" class="button" data-analytics="DCSext.GeneralLinks,SendFeedback)">Send feedback</button>
+        <button type="reset" class="button button__cancel" data-analytics="DCSext.GeneralLinks,CancelFeedback)">Cancel</button>
 
         <input type="hidden" name="feedback-form-path" value="{{ FEEDBACKFORM.path }}">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">

--- a/app/views/_includes/new-site-message.nunjucks
+++ b/app/views/_includes/new-site-message.nunjucks
@@ -2,10 +2,10 @@
   <p class="notification-banner--inner">
     This is a new page.
     {% if feedback and not FEEDBACKFORM.disabled and FEEDBACKFORM.outcome != "success"  %}
-      <a href="#page-feedback" class="js-feedback-toggle" onclick="dcsMultiTrack('DCSext.GeneralLinks','TellUsWhatYouThink','WT.dl','121')">Tell us what you think</a> or go
+      <a href="#page-feedback" class="js-feedback-toggle" data-analytics="DCSext.GeneralLinks,TellUsWhatYouThink">Tell us what you think</a> or go
     {% else %}
       Go
     {% endif %}
-    <a href="http://www.nhs.uk/{{ choicesOrigin }}" onclick="dcsMultiTrack('DCSext.GeneralLinks','BackToChoices','WT.dl','121')">back to NHS Choices.</a>
+    <a href="http://www.nhs.uk/{{ choicesOrigin }}" data-analytics="DCSext.GeneralLinks,BackToChoices">back to NHS Choices.</a>
   </p>
 </div>

--- a/app/views/fungal-nail-infection.nunjucks
+++ b/app/views/fungal-nail-infection.nunjucks
@@ -16,7 +16,7 @@
         srcset="{{ asset_path('assets/images/fungal-nail-infection/stage-1-300.jpg') }} 300w,
                 {{ asset_path('assets/images/fungal-nail-infection/stage-1-600.jpg') }} 600w"
         alt="Fungal infection at the edge of the nail"
-        onclick="dcsMultiTrack('DCSext.FungalNailImages','Edge','WT.dl','121')" />
+        data-analytics="DCSext.FungalNailImages,Edge" />
       <noscript>
         <img src="{{ asset_path('assets/images/fungal-nail-infection/stage-1-300.jpg') }}" alt="Fungal infection at the edge of the nail" />
       </noscript>
@@ -30,7 +30,7 @@
         srcset="{{ asset_path('assets/images/fungal-nail-infection/stage-2-300.jpg') }} 300w,
                 {{ asset_path('assets/images/fungal-nail-infection/stage-2-600.jpg') }} 600w"
         alt="Infection spread to the middle of the toe"
-        onclick="dcsMultiTrack('DCSext.FungalNailImages','Spread','WT.dl','121')" />
+        data-analytics="DCSext.FungalNailImages,Spread" />
       <noscript>
         <img src="{{ asset_path('assets/images/fungal-nail-infection/stage-2-300.jpg') }}" alt="Infection spread to the middle of the toe" />
       </noscript>
@@ -44,7 +44,7 @@
         srcset="{{ asset_path('assets/images/fungal-nail-infection/stage-3-300.jpg') }} 300w,
                 {{ asset_path('assets/images/fungal-nail-infection/stage-3-600.jpg') }} 600w"
         alt="Brittle nail with pieces missing"
-        onclick="dcsMultiTrack('DCSext.FungalNailImages','Brittle','WT.dl','121')" />
+        data-analytics="DCSext.FungalNailImages,Brittle" />
       <noscript>
         <img src="{{ asset_path('assets/images/fungal-nail-infection/stage-3-300.jpg') }}" alt="Brittle nail with pieces missing" />
       </noscript>

--- a/app/views/rashes-in-babies-and-children.nunjucks
+++ b/app/views/rashes-in-babies-and-children.nunjucks
@@ -7,16 +7,16 @@
 
   <ul class="link-list">
     <li class="link-list--item">
-      <a href="#emergency-info" class="link__reverse-polarity" onclick="dcsMultiTrack('DCSext.RashesChildrenAnchor','Emergency','WT.dl','121')">Emergency information</a>
+      <a href="#emergency-info" class="link__reverse-polarity" data-analytics="DCSext.RashesChildrenAnchor,Emergency">Emergency information</a>
     </li>
     <li class="link-list--item">
-      <a href="#rash-with-fever" class="link__reverse-polarity" onclick="dcsMultiTrack('DCSext.RashesChildrenAnchor','Fever','WT.dl','121')">Rash with fever</a>
+      <a href="#rash-with-fever" class="link__reverse-polarity" data-analytics="DCSext.RashesChildrenAnchor,Fever">Rash with fever</a>
     </li>
     <li class="link-list--item">
-      <a href="#rash-with-itching" class="link__reverse-polarity" onclick="dcsMultiTrack('DCSext.RashesChildrenAnchor','Itching','WT.dl','121')">Rash with itching</a>
+      <a href="#rash-with-itching" class="link__reverse-polarity" data-analytics="DCSext.RashesChildrenAnchor,Itching">Rash with itching</a>
     </li>
     <li class="link-list--item">
-      <a href="#rash-without-fever-or-itching" class="link__reverse-polarity" onclick="dcsMultiTrack('DCSext.RashesChildrenAnchor','Without','WT.dl','121')">Rash without fever or itching</a>
+      <a href="#rash-without-fever-or-itching" class="link__reverse-polarity" data-analytics="DCSext.RashesChildrenAnchor,Without">Rash without fever or itching</a>
     </li>
   </ul>
 {% endblock %}
@@ -66,7 +66,7 @@
                 {{ asset_path('assets/images/rashes-in-babies-and-children/fever-and-red-cheeks-800.jpg') }} 800w,
                 {{ asset_path('assets/images/rashes-in-babies-and-children/fever-and-red-cheeks-1280.jpg') }} 1280w"
         alt="A child’s face showing a bright red rash on both cheeks"
-        onclick="dcsMultiTrack('DCSext.RashesChildrenImages','FeverRedCheeks','WT.dl','121')" />
+        data-analytics="DCSext.RashesChildrenImages,FeverRedCheeks" />
       <noscript>
         <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/fever-and-red-cheeks-400.jpg') }}" alt="A child’s face showing a bright red rash on both cheeks" />
       </noscript>
@@ -88,7 +88,7 @@
                 {{ asset_path('assets/images/rashes-in-babies-and-children/chicken-pox-800.jpg') }} 800w,
                 {{ asset_path('assets/images/rashes-in-babies-and-children/chicken-pox-1280.jpg') }} 1280w"
         alt="A baby covered in small spots"
-        onclick="dcsMultiTrack('DCSext.RashesChildrenImages','SmallSpotsBlisters','WT.dl','121')" />
+        data-analytics="DCSext.RashesChildrenImages,SmallSpotsBlisters" />
       <noscript>
         <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/chicken-pox-400.jpg') }}" alt="A baby covered in small spots" />
       </noscript>
@@ -107,7 +107,7 @@
                 {{ asset_path('assets/images/rashes-in-babies-and-children/hand-foot-and-mouth-800.jpg') }} 800w,
                 {{ asset_path('assets/images/rashes-in-babies-and-children/hand-foot-and-mouth-1280.jpg') }} 1280w"
         alt="Blisters on the small finger on a hand"
-        onclick="dcsMultiTrack('DCSext.RashesChildrenImages','BlistersOnHands','WT.dl','121')" />
+        data-analytics="DCSext.RashesChildrenImages,BlistersOnHands" />
       <noscript>
         <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/fever-and-red-cheeks-400.jpg') }}" alt="Blisters on the small finger on a hand" />
       </noscript>
@@ -129,7 +129,7 @@
                 {{ asset_path('assets/images/rashes-in-babies-and-children/scarlet-fever-800.jpg') }} 800w,
                 {{ asset_path('assets/images/rashes-in-babies-and-children/scarlet-fever-1280.jpg') }} 1280w"
         alt="A child’s chest and shoulders covered in a pink-red rash"
-        onclick="dcsMultiTrack('DCSext.RashesChildrenImages','PinkRedRash','WT.dl','121')" />
+        data-analytics="DCSext.RashesChildrenImages,PinkRedRash" />
       <noscript>
         <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/scarlet-fever-400.jpg') }}" alt="A child’s chest and shoulders covered in a pink-red rash" />
       </noscript>
@@ -158,7 +158,7 @@
                 {{ asset_path('assets/images/rashes-in-babies-and-children/heat-rash-800.jpg') }} 800w,
                 {{ asset_path('assets/images/rashes-in-babies-and-children/heat-rash-1280.jpg') }} 1280w"
         alt="A child’s back showing a heat rash under a pulled up t-shirt"
-        onclick="dcsMultiTrack('DCSext.RashesChildrenImages','RashesHeat','WT.dl','121')" />
+        data-analytics="DCSext.RashesChildrenImages,RashesHeat" />
       <noscript>
         <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/heat-rash-400.jpg') }}" alt="A child’s back showing a heat rash under a pulled up t-shirt" />
       </noscript>
@@ -180,7 +180,7 @@
                 {{ asset_path('assets/images/rashes-in-babies-and-children/eczma-800.jpg') }} 800w,
                 {{ asset_path('assets/images/rashes-in-babies-and-children/eczma-1280.jpg') }} 1280w"
         alt="Back of a child’s knees showing red, cracked skin"
-        onclick="dcsMultiTrack('DCSext.RashesChildrenImages','ScalyCrackedSkin','WT.dl','121')" />
+        data-analytics="DCSext.RashesChildrenImages,ScalyCrackedSkin" />
       <noscript>
         <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/eczma-400.jpg') }}" alt="Back of a child’s knees showing red, cracked skin" />
       </noscript>
@@ -202,7 +202,7 @@
                 {{ asset_path('assets/images/rashes-in-babies-and-children/hives-800.jpg') }} 800w,
                 {{ asset_path('assets/images/rashes-in-babies-and-children/hives-1280.jpg') }} 1280w"
         alt="Side of a child’s knee showing hives"
-        onclick="dcsMultiTrack('DCSext.RashesChildrenImages','RaisedItchySpots','WT.dl','121')" />
+        data-analytics="DCSext.RashesChildrenImages,RaisedItchySpots" />
       <noscript>
         <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/hives-400.jpg') }}" alt="Side of a child’s knee showing hives" />
       </noscript>
@@ -230,7 +230,7 @@
                 {{ asset_path('assets/images/rashes-in-babies-and-children/ringworm-800.jpg') }} 800w,
                 {{ asset_path('assets/images/rashes-in-babies-and-children/ringworm-1280.jpg') }} 1280w"
         alt="Ringworm rash on skin"
-        onclick="dcsMultiTrack('DCSext.RashesChildrenImages','ItchyRoundRash','WT.dl','121')" />
+        data-analytics="DCSext.RashesChildrenImages,ItchyRoundRash" />
       <noscript>
         <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/ringworm-400.jpg') }}" alt="Ringworm rash on skin" />
       </noscript>
@@ -259,7 +259,7 @@
                 {{ asset_path('assets/images/rashes-in-babies-and-children/milia-800.jpg') }} 800w,
                 {{ asset_path('assets/images/rashes-in-babies-and-children/milia-1280.jpg') }} 1280w"
         alt="Close-up of a baby’s nose showing small white spots"
-        onclick="dcsMultiTrack('DCSext.RashesChildrenImages','WhiteSpotsBabies','WT.dl','121')" />
+        data-analytics="DCSext.RashesChildrenImages,WhiteSpotsBabies" />
       <noscript>
         <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/milia-400.jpg') }}" alt="Close-up of a baby’s nose showing small white spots" />
       </noscript>
@@ -278,7 +278,7 @@
                 {{ asset_path('assets/images/rashes-in-babies-and-children/erythema-800.jpg') }} 800w,
                 {{ asset_path('assets/images/rashes-in-babies-and-children/erythema-1280.jpg') }} 1280w"
         alt="Baby’s head and shoulders showing raised spots"
-        onclick="dcsMultiTrack('DCSext.RashesChildrenImages','RedYellowWhiteSpots','WT.dl','121')" />
+        data-analytics="DCSext.RashesChildrenImages,RedYellowWhiteSpots" />
       <noscript>
         <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/erythema-400.jpg') }}" alt="Baby’s head and shoulders showing raised spots" />
       </noscript>
@@ -303,7 +303,7 @@
                 {{ asset_path('assets/images/rashes-in-babies-and-children/molluscum-800.jpg') }} 800w,
                 {{ asset_path('assets/images/rashes-in-babies-and-children/molluscum-1280.jpg') }} 1280w"
         alt="Small, pink raised spots on skin"
-        onclick="dcsMultiTrack('DCSext.RashesChildrenImages','PinkSkinColoured','WT.dl','121')" />
+        data-analytics="DCSext.RashesChildrenImages,PinkSkinColoured" />
       <noscript>
         <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/molluscum-400.jpg') }}" alt="Small, pink raised spots on skin" />
       </noscript>
@@ -325,7 +325,7 @@
                 {{ asset_path('assets/images/rashes-in-babies-and-children/nappy-800.jpg') }} 800w,
                 {{ asset_path('assets/images/rashes-in-babies-and-children/nappy-1280.jpg') }} 1280w"
         alt="Red patch on a baby’s bottom"
-        onclick="dcsMultiTrack('DCSext.RashesChildrenImages','RedPatches','WT.dl','121')" />
+        data-analytics="DCSext.RashesChildrenImages,RedPatches" />
       <noscript>
         <img src="{{ asset_path('assets/images/rashes-in-babies-and-children/nappy-400.jpg') }}" alt="Red patch on a baby’s bottom" />
       </noscript>

--- a/assets/javascripts/modules/analytics.js
+++ b/assets/javascripts/modules/analytics.js
@@ -1,0 +1,57 @@
+/* globals dcsMultiTrack */
+
+// Analytics Utility module
+// This module offers ways to send custom events to analytics packages:
+// - by calling analytics.send. Eg. analytics.send('name', 'value')
+// - by adding the data-analytics attribute to any element that can be clicked
+//   eg <div data-analytics="name1,value1,name2,value2"/>
+// It needs the analytics tracking code to be enabled on the page
+const $ = require('jquery');
+
+const Analytics = function Analytics() {
+  this.attrName = 'analytics';
+};
+
+Analytics.prototype.init = function init() {
+  this.cacheEls();
+  this.bindEvents();
+};
+
+Analytics.prototype.cacheEls = function cacheEls() {
+  this.$body = $('body');
+};
+
+Analytics.prototype.bindEvents = function bindEvents() {
+  this.$body
+    .on('click.analytics', `[data-${this.attrName}]`, $.proxy(this._sendFromEvent, this));
+};
+
+Analytics.prototype.send = function send(...args) {
+  if (this._wtExists()) {
+    // add required args for webtrends call
+    args.push('WT.dl');
+    args.push('121');
+
+    try {
+      // call webtrends track function with arguments
+      dcsMultiTrack.apply(this, args);
+    } catch (e) {
+      throw e;
+    }
+  }
+};
+
+Analytics.prototype._sendFromEvent = function _sendFromEvent(e) {
+  const analyticsParams = $(e.target).data(this.attrName).split(',');
+  this.send.apply(this, analyticsParams);
+};
+
+Analytics.prototype._gaExists = function _gaExists() {
+  return typeof ga === typeof Function;
+};
+
+Analytics.prototype._wtExists = function _wtExists() {
+  return typeof dcsMultiTrack === typeof Function;
+};
+
+module.exports = new Analytics();

--- a/assets/javascripts/nhsuk.js
+++ b/assets/javascripts/nhsuk.js
@@ -1,5 +1,7 @@
 const cookieMessage = require('./modules/cookie-message');
 const feedbackForm = require('./modules/feedback-form');
+const analytics = require('./modules/analytics');
 
 cookieMessage('global-cookies-banner');
 feedbackForm.init();
+analytics.init();


### PR DESCRIPTION
This allows any changes to the global call to be managed in one place as
well as checking that the analytics object exists before making the call.

This PR fixes #116 