### PR TITLE
Use correct check for serving elements route

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -25,7 +25,7 @@ router.all('/conditions/fungal-nail-infection', fungalNailInfectionController.in
 router.all('/symptoms/rashes-in-babies-and-children', rashesInChildrenController.index);
 router.all('/symptoms/stomach-ache', stomachAcheController.index);
 
-if (config !== 'production') {
+if (config.env === 'development') {
   router.get('/elements', elementsController.index);
 }
 


### PR DESCRIPTION
I realised this check wasn't actually doing what it needed to because it was checking against the whole config object rather than the `env` property. Oops.

This fix makes sure the elements route is only served during development.