### PR TITLE
Revert "Revert "Store user IP address in feedback""

### DIFF
--- a/app/middleware/feedback.js
+++ b/app/middleware/feedback.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-param-reassign */
+const requestIp = require('request-ip');
 const feedbackApi = require('../../lib/feedback-api');
 const logger = require('../../lib/logger');
 const config = require('../../config/config');
@@ -27,6 +28,7 @@ module.exports = () => {
         req.sanitizeBody('feedback-form-path');
 
         const formData = {
+          ip: requestIp.getClientIp(req),
           comment: req.body['feedback-form-comments'],
           path: req.body['feedback-form-path'],
         };

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "picturefill": "~3.0.2",
     "pre-commit": "~1.1.3",
     "request": "~2.74.0",
+    "request-ip": "^1.2.2",
     "require-dir": "~0.3.0",
     "serve-favicon": "~2.3.0",
     "webpack": "~1.13.2",


### PR DESCRIPTION
This adds back in the IP address collection for feedback to add more advanced tracking with Webtrends.

This effectively "un-reverts" the original revert.