### PR TITLE
Prevent assets from being routed through content controller

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -4,8 +4,9 @@ const developmentOnlyController = require('../app/controllers/development-only')
 const healthcheckController = require('../app/controllers/healthcheck');
 const contentPageController = require('../app/controllers/content-page');
 
+router.all('/', contentPageController.index);
 router.get('/:slug(elements)', developmentOnlyController.index);
 router.get('/healthcheck', healthcheckController.index);
-router.all('*', contentPageController.index);
+router.all('/*(help|symptoms|conditions)/*?', contentPageController.index);
 
 module.exports = router;


### PR DESCRIPTION
This swaps the route search from a wildcard to include allowed routes so
unnecessary files like assets that can't be found don't get passed through
this controller first.