### PR TITLE
Add diabetes type 2 guide

### DIFF
--- a/content/conditions/type-2-diabetes/check-if-you-have-it/main-content.md
+++ b/content/conditions/type-2-diabetes/check-if-you-have-it/main-content.md
@@ -1,0 +1,34 @@
+## How to tell if you have type 2 diabetes
+
+Many people have type 2 diabetes and don’t realise. This is because symptoms
+don’t necessarily make you feel unwell.
+
+Symptoms of type 2 diabetes include:
+
+* peeing more than usual, particularly at night
+* feeling thirsty all the time
+* feeling very tired
+* losing weight without trying
+* itching around your penis or vagina, or you keep getting thrush
+* cuts or wounds that take longer to heal
+* blurred vision
+
+You’re more at risk of developing type 2 diabetes if you:
+
+* are over 40 (or 25 for South Asian people)
+* have a close relative with diabetes (parent, brother or sister)
+* are overweight or obese
+* are of South Asian, Chinese, African-Caribbean or black African origin
+  (even if you were born in the UK)
+
+### When to see your GP
+
+See your GP if you have any of the symptoms of type 2 diabetes, or you're
+worried you may have a higher risk of developing it.
+
+[Your GP can diagnose diabetes.](getting-diagnosed) You’ll need a blood test
+which you may have to go to your local health center for if it can’t be done at
+your GP surgery.
+
+The earlier diabetes is diagnosed and treatment starts, the better. Treating
+diabetes early reduces your risk of [other health problems.](health-problems)

--- a/content/conditions/type-2-diabetes/check-if-you-have-it/manifest.json
+++ b/content/conditions/type-2-diabetes/check-if-you-have-it/manifest.json
@@ -1,0 +1,12 @@
+{
+  "layout": "content-simple",
+  "guide": true,
+  "title": "Check if you have it",
+  "choicesOrigin": "",
+  "main": [
+    {
+      "type": "content_block",
+      "content": "!file=main-content.md"
+    }
+  ]
+}

--- a/content/conditions/type-2-diabetes/finding-help-and-support/main-content.md
+++ b/content/conditions/type-2-diabetes/finding-help-and-support/main-content.md
@@ -1,0 +1,55 @@
+## Finding help and support for type 2 diabetes
+
+There is a lot of information and support available for type 2 diabetes.
+Some of the support depends on the area you live in.
+
+### Take a course to help you manage your diabetes
+
+There are free education courses to help you learn more about and manage your
+type 2 diabetes.
+
+Your GP will need to refer you. You can phone your GP surgery to get a referral
+letter, you don’t need to make an appointment.
+
+Read more information about [education courses for type 2 diabetes](http://www.desmond-project.org.uk/newlydiagnosedandfoundationmodules-278.html)
+
+### Telling DVLA you have type 2 diabetes
+
+If you're taking insulin for your type 2 diabetes, you will need to
+[tell the DVLA](https://www.gov.uk/diabetes-driving). This is because of the
+risk of hypoglycaemia. You can be fined if you don’t tell DVLA.
+
+### Support groups for type 2 diabetes
+
+The charity Diabetes UK runs [local support groups.](https://www.diabetes.org.uk/How_we_help/Local_support_groups/)
+
+They can help with things like managing your diabetes on a daily basis, diet,
+exercise or dealing with emotional problems like depression. They’re a place to
+talk and find out how others live with the condition.
+
+### Blogs and forums about diabetes
+
+* [Diabetes.co.uk forum](http://www.diabetes.co.uk/forum/) --- discussions about
+  living with and managing diabetes
+* [Diabetes UK blogs](http://blogs.diabetes.org.uk/) --- collection of different
+  blogs on food, eyes, work and diabetes and more
+* [Diabetes Chat](http://www.diabetes.co.uk/diabetes-chat/) --- offers scheduled
+  chats with healthcare professionals or just the chance to talk to others
+
+### Telling others can be difficult
+
+However, it can help for certain people to know you have diabetes:
+
+* family can support you, especially as you will need to make changes to what you eat
+* it’s important your colleagues or employer know in case of an emergency
+* being diagnosed with diabetes can affect your mood --- telling your partner
+  will help them understand how you feel
+
+### Carry Medical ID in case of an emergency
+
+Some people choose to wear a special wristband or carry something in their
+wallet that says they have diabetes, in case there is a medical emergency.
+
+Knowing you have diabetes can make a difference to the treatment you’ll be given.
+
+Search the internet for ‘medical ID’ to find a website that sells them.

--- a/content/conditions/type-2-diabetes/finding-help-and-support/manifest.json
+++ b/content/conditions/type-2-diabetes/finding-help-and-support/manifest.json
@@ -1,0 +1,12 @@
+{
+  "layout": "content-simple",
+  "guide": true,
+  "title": "Finding help and support",
+  "choicesOrigin": "",
+  "main": [
+    {
+      "type": "content_block",
+      "content": "!file=main-content.md"
+    }
+  ]
+}

--- a/content/conditions/type-2-diabetes/food-and-keeping-active/main-content.md
+++ b/content/conditions/type-2-diabetes/food-and-keeping-active/main-content.md
@@ -1,0 +1,65 @@
+## Food and keeping active
+
+A healthy diet and keeping active will help you manage your blood sugar level.
+They’ll also help you to control your weight and generally feel better.
+
+### You can eat many types of foods
+
+There’s nothing you can’t eat, but you’ll have to limit certain foods.
+
+You should:
+
+* eat a wide range of foods --- including fruit, vegetables, some starchy foods
+  such as pasta
+* keep sugar, fat and salt to a minimum
+* eat breakfast, lunch and dinner every day --- don’t skip meals
+
+If you need to change your diet, it might be easier to make small changes every
+week.
+
+Information about food can be found on these diabetes sites:
+
+* [food for people with diabetes](https://www.diabetes.org.uk/Guide-to-diabetes/Enjoy-food/Eating-with-diabetes/What-is-a-healthy-balanced-diet/)
+* [tips on eating with your family and eating out](https://www.diabetes.org.uk/Guide-to-diabetes/Enjoy-food/Eating-with-diabetes/)
+* [recipes for people with diabetes](https://www.diabetes.org.uk/Guide-to-diabetes/Enjoy-food/Cooking-for-people-with-diabetes/)
+* [food and nutrition message board](http://www.diabetes.co.uk/forum/category/food-nutrition-and-recipes.3/)
+
+!!! warning
+Once a year you should go for a [regular diabetes check](going-for-regular-check-ups)
+to make sure your blood pressure and your cholesterol (blood fats) level are ok.
+!!!
+
+### Help with changing your diet
+
+If you find it hard to change your diet, a dietitian might be able to help.
+
+Talk to your GP or diabetes nurse to see if the cost could be covered through
+the NHS.
+
+### Being active lowers your blood sugar level
+
+Physical exercise helps lower your blood sugar level. You should aim for 2.5
+hours of activity per week.
+
+You can be active anywhere, as long as what you’re doing makes you out of
+breath. This could be:
+
+* fast walking
+* climbing stairs
+* doing more strenuous housework or gardening
+
+The charity Diabetes UK has [tips on how to get active.](https://www.diabetes.org.uk/Guide-to-diabetes/Managing-your-diabetes/Exercise/)
+
+### Your weight is important
+
+Losing weight (if you’re overweight) will make it easier for your body to lower
+your blood sugar level and can improve your blood pressure and cholesterol
+(blood fats).
+
+To know whether you’re overweight, work out your
+[body mass index (BMI).](http://www.nhs.uk/Tools/Pages/Healthyweightcalculator.aspx)
+
+If you need to lose weight, try and do it slowly over time, about 0.5 to 1 kilo a week.
+
+The charity Diabetes UK has more
+[information on healthy weight and weight loss.](https://www.diabetes.org.uk/Guide-to-diabetes/Enjoy-food/Eating-with-diabetes/Whats-your-healthy-weight/)

--- a/content/conditions/type-2-diabetes/food-and-keeping-active/manifest.json
+++ b/content/conditions/type-2-diabetes/food-and-keeping-active/manifest.json
@@ -1,0 +1,12 @@
+{
+  "layout": "content-simple",
+  "guide": true,
+  "title": "Food and keeping active",
+  "choicesOrigin": "",
+  "main": [
+    {
+      "type": "content_block",
+      "content": "!file=main-content.md"
+    }
+  ]
+}

--- a/content/conditions/type-2-diabetes/getting-diagnosed/main-content.md
+++ b/content/conditions/type-2-diabetes/getting-diagnosed/main-content.md
@@ -1,0 +1,59 @@
+## Getting diagnosed
+
+Type 2 diabetes is often diagnosed following blood or urine tests for
+something else.
+
+However, if you have any [symptoms of diabetes](check-if-you-have-it) you
+should see your GP straight away.
+
+To find out if you have type 2 diabetes, you usually have to go through the
+following steps:
+
+1. Speak to your GP about your symptoms.
+2. Your GP will check your urine and arrange a blood test to check your blood
+   sugar levels. It usually takes about 1 to 2 days for the results to come back.
+3. If you have diabetes, your GP will ask you to come in again to explain the
+   test results and what will happen next.
+
+### If you’re diagnosed with diabetes
+
+What your GP will discuss with you during your appointment depends on the
+diagnosis and the treatment they recommend.
+
+Generally, they’ll talk to you about:
+
+* what diabetes is
+* what high blood sugar means for your health
+* what medication you’ll have to take
+* your diet and exercise
+* your lifestyle, for example alcohol and smoking
+
+!!! warning
+Your GP will do their best to discuss the diagnosis with you but this first
+appointment might only be 10 to 15 minutes.
+!!!
+
+### If you have questions about your diagnosis
+
+It’s usually difficult to take in everything the GP tells you during the
+appointment.
+
+Talk to family and friends about what the GP told you and write down all the
+questions you have.
+
+Then make another GP appointment and take your list of questions with you.
+
+There’s also a lot of [information on diabetes](finding-help-and-support)
+available.
+
+### What happens after the diagnosis
+
+Usually the following things happen after your diagnosis:
+
+1. Your GP will prescribe [medication](understanding-medication). It might take
+   time for you to get used to the medication and to find the right amounts for you.
+2. You might need to make changes to your [diet and be more active.](food-and-keeping-active)
+3. You’ll have to go for [regular type 2 diabetes check ups.](going-for-regular-check-ups)
+4. You’ll have to look out for certain signs to avoid
+   [other health problems.](health-problems)
+5. Ask your GP about a [free education course for type 2 diabetes](http://www.desmond-project.org.uk/newlydiagnosedandfoundationmodules-278.html)

--- a/content/conditions/type-2-diabetes/getting-diagnosed/manifest.json
+++ b/content/conditions/type-2-diabetes/getting-diagnosed/manifest.json
@@ -1,0 +1,12 @@
+{
+  "layout": "content-simple",
+  "guide": true,
+  "title": "Getting diagnosed",
+  "choicesOrigin": "",
+  "main": [
+    {
+      "type": "content_block",
+      "content": "!file=main-content.md"
+    }
+  ]
+}

--- a/content/conditions/type-2-diabetes/going-for-regular-check-ups/main-content.md
+++ b/content/conditions/type-2-diabetes/going-for-regular-check-ups/main-content.md
@@ -1,0 +1,39 @@
+## Going for regular check ups
+
+Type 2 diabetes check ups help to make sure your condition doesn’t lead to other
+health problems.
+
+### Every 3 months
+
+#### Blood sugar checks (HbA1C test)
+
+Checks your average blood sugar levels and how close they are to normal.
+
+You have these checks every 3 months when newly diagnosed, then every 6 months
+once you’re stable.
+
+This can be done by your GP or diabetes nurse.
+
+### Once a year
+
+#### Feet
+
+Checks if you’ve lost any feeling in your feet and for ulcers and infections.
+
+This can be done by your GP, diabetes nurse or podiatrist
+
+Speak to your GP immediately if you have cuts, bruises, or numbness in your feet.
+
+#### Eyes
+
+Checks for damage to blood vessels in your eyes.
+
+Speak to your GP immediately if you have blurred vision.
+
+#### Blood pressure, blood fats (cholesterol) and kidneys
+
+Checks for high blood pressure, heart and kidney disease.
+
+This can be done by your GP or diabetes nurse.
+
+[Why it’s important to have these check ups](health-problems)

--- a/content/conditions/type-2-diabetes/going-for-regular-check-ups/manifest.json
+++ b/content/conditions/type-2-diabetes/going-for-regular-check-ups/manifest.json
@@ -1,0 +1,12 @@
+{
+  "layout": "content-simple",
+  "guide": true,
+  "title": "Going for regular check ups",
+  "choicesOrigin": "",
+  "main": [
+    {
+      "type": "content_block",
+      "content": "!file=main-content.md"
+    }
+  ]
+}

--- a/content/conditions/type-2-diabetes/health-problems/main-content.md
+++ b/content/conditions/type-2-diabetes/health-problems/main-content.md
@@ -1,0 +1,98 @@
+## Health problems caused by type 2 diabetes
+
+You need to watch your health and have regular check-ups if you have type 2
+diabetes because it can lead to:
+
+* [heart disease](http://www.nhs.uk/conditions/coronary-heart-disease/pages/introduction.aspx) and [stroke](http://www.nhs.uk/Conditions/Stroke/Pages/Introduction.aspx)
+* loss of feeling and pain (nerve damage) --- causing problems with sex
+* foot problems --- sores and infections
+* vision loss and blindness
+* miscarriage and stillbirth
+* problems with your kidneys
+
+Controlling your blood sugar level and having regular diabetes check-ups is
+the best way to lower your risk of complications.
+
+### Getting your heart checked
+
+You should have your blood fats (cholesterol) and blood pressure checked at least
+once a year. Diabetes increases your risk of heart disease and stroke so it’s
+important high blood pressure and high cholesterol is spotted and treated early.
+
+If you’re already being treated for high cholesterol and high blood pressure,
+keep taking your medicine.
+
+Diabetes also worsens the effects of smoking on your heart.
+[Get help to quit smoking.](http://www.nhs.uk/LiveWell/Smoking/Pages/stopsmokingnewhome.aspx)
+
+### Loss of feeling
+
+You should let your GP or diabetes nurse know if you notice any changes in your
+body.
+
+Diabetes can damage your nerves (neuropathy). This usually affects your feet,
+but it can affect other parts of your body, causing:
+
+* numbness
+* pain or tingling
+* problems with sex
+* constipation or diarrhoea
+
+Early treatment can prevent nerve damage getting worse.
+
+### Looking after your feet
+
+You should check your feet every day.
+
+Diabetes can reduce the blood supply to your feet and cause a loss of feeling.
+This means:
+
+* foot injuries don’t heal well
+* you may not notice if your foot is sore or injured
+
+These can lead to ulcers and infections.
+
+Simple things are important, like:
+
+* keeping feet clean and dry to avoid infection
+* trying not to go barefoot outside to avoid niks and cuts
+* wearing shoes that fit well
+
+Speak to your GP or diabetes nurse if you notice any changes in your feet,
+including:
+
+* cuts, cracks or blisters
+* pain or tingling
+* numb feet
+
+Diabetes UK has advice on
+[how to check your feet](https://www.diabetes.org.uk/Guide-to-diabetes/Complications/Feet/)
+
+Your feet should also be checked every year by your GP, diabetes nurse or
+podiatrist.
+
+Sores or infections that aren’t treated early can lead to gangrene. More than
+135 amputations are carried out every week in the UK due to diabetes.
+
+### Checking your eyes
+
+[Your eyes should be checked every year](http://www.nhs.uk/Conditions/diabetic-eye-screening/Pages/Introduction.aspx)
+for damaged blood vessels, which can cause sight problems
+[(diabetic retinopathy)](http://www.nhs.uk/Conditions/Diabetic-retinopathy/Pages/Introduction.aspx) and blindness.
+
+Diabetes eye checks can detect damage before it affects your sight. Treating
+damaged blood vessels early can prevent sight problems.
+
+Speak to your GP immediately if you notice changes to your sight, including:
+
+* blurred vision, especially at night
+* shapes floating in your sight (floaters)
+* sensitivity to light
+
+### Pregnancy and diabetes
+
+Speak to your GP or care team if you’re thinking of having a baby.
+
+You can have a safe pregnancy and birth if you have type 2 diabetes. You will
+need to take extra precautions and have more appointments before and during
+pregnancy.

--- a/content/conditions/type-2-diabetes/health-problems/manifest.json
+++ b/content/conditions/type-2-diabetes/health-problems/manifest.json
@@ -1,0 +1,12 @@
+{
+  "layout": "content-simple",
+  "guide": true,
+  "title": "Health problems",
+  "choicesOrigin": "",
+  "main": [
+    {
+      "type": "content_block",
+      "content": "!file=main-content.md"
+    }
+  ]
+}

--- a/content/conditions/type-2-diabetes/manifest.json
+++ b/content/conditions/type-2-diabetes/manifest.json
@@ -1,0 +1,13 @@
+{
+  "layout": "guide",
+  "title": "Type 2 diabetes",
+  "pages": [
+    "check-if-you-have-it",
+    "getting-diagnosed",
+    "understanding-medication",
+    "going-for-regular-check-ups",
+    "health-problems",
+    "food-and-keeping-active",
+    "finding-help-and-support"
+  ]
+}

--- a/content/conditions/type-2-diabetes/understanding-medication/main-content.md
+++ b/content/conditions/type-2-diabetes/understanding-medication/main-content.md
@@ -1,0 +1,76 @@
+## Understanding medication
+
+Most people need medicine to control their type 2 diabetes. Medicine helps keep
+your blood sugar level as normal as possible to prevent health problems. You’ll
+have to take it for the rest of your life.
+
+Diabetes usually gets worse over time so your medicine or dose will need to change.
+
+[Adjusting your diet and being active](food-and-keeping-active) is also
+necessary to keep your blood sugar level down.
+
+### Getting the right medicine for you
+
+Diabetes medicines help lower the amount of sugar in your blood.
+
+!!! warning
+There are many types of medicine for type 2 diabetes. It can take time to find
+a medicine and dose that’s right for you.
+!!!
+
+You’ll usually be offered a medicine called metformin first. If your blood
+sugar levels haven’t lowered within 3 months, you may need another medicine.
+
+Over time, you may need a combination of medicines. Your GP or diabetes nurse
+will recommend the medicines most suitable for you.
+
+Insulin isn't often used for type 2 diabetes in the early years. It’s needed
+only when other medicines no longer work.
+
+Diabetes UK has more information about
+[taking medicines for type 2 diabetes.](https://www.diabetes.org.uk/Guide-to-diabetes/What-is-diabetes/Diabetes-treatments/)
+
+### Taking your medicine
+
+Your GP or diabetes nurse will explain how to take your medicine and how to
+store it. If you need to inject insulin or a medicine called gliptins, they’ll
+show you how to do it.
+
+### Side effects
+
+Your diabetes medicine may cause side effects. These can include:
+
+* bloating and diarrhoea
+* weight loss or weight gain
+* feeling sick
+* swollen ankles
+
+Not everyone has side effects.
+
+If you feel unwell after taking medicine or notice any side effects, speak to
+your GP or diabetes nurse. Don’t stop taking medication without advice.
+
+### How to get free prescriptions for diabetes medication
+
+You’re entitled to free prescriptions for your diabetes medication.
+
+To claim your free prescriptions you’ll need to apply for an exemption
+certificate. To do this:
+
+* fill in a form at your GP surgery
+* you should get the certificate in the post about a week later
+  (it will last 5 years)
+* take it to your pharmacy with your prescriptions
+
+Save your receipts if you have to pay for diabetes medication before you receive
+your exemption certificate so you can claim money back.
+
+### Travelling with diabetes medicines
+
+If you’re going on holiday:
+
+* pack extra medicine --- speak to your diabetes nurse about how much
+* carry your medicine in your hand luggage in case your checked-in bags go
+  missing or are damaged
+* if you're flying with a medicine you inject, get a letter from your GP that
+  says you need it to treat diabetes

--- a/content/conditions/type-2-diabetes/understanding-medication/manifest.json
+++ b/content/conditions/type-2-diabetes/understanding-medication/manifest.json
@@ -1,0 +1,12 @@
+{
+  "layout": "content-simple",
+  "guide": true,
+  "title": "Understanding medication",
+  "choicesOrigin": "",
+  "main": [
+    {
+      "type": "content_block",
+      "content": "!file=main-content.md"
+    }
+  ]
+}

--- a/content/index/main-content.md
+++ b/content/index/main-content.md
@@ -6,10 +6,11 @@ take a look and tell us what you think. It will help us to improve what we do.
 ## Conditions
 
 * [Fungal nail infection](/conditions/fungal-nail-infection)
-* [Shingles](/conditions/shingles)
-* [Head lice](/conditions/head-lice)
-* [Warts](/conditions/warts)
 * [Hand, foot and mouth disease](/conditions/hand-foot-and-mouth-disease)
+* [Head lice](/conditions/head-lice)
+* [Shingles](/conditions/shingles)
+* [Warts](/conditions/warts)
+* [Diabetes](/conditions/type-2-diabetes/check-if-you-have-it)
 
 ## Symptoms
 


### PR DESCRIPTION
Adds the type 2 diabetes guide content. 

This has been separated out to make it easier to review. 

It relies on #157 being merged first.