### PR TITLE
Update gulp revision whitelist

### DIFF
--- a/gulp/tasks/rev.js
+++ b/gulp/tasks/rev.js
@@ -18,6 +18,20 @@ gulp.task('rev', () => {
     .pipe(revAll.revision({
       hashLength: 32,
       dontRenameFile: ['rev-manifest.json'],
+      includeFilesInManifest: [
+        '.css',
+        '.js',
+        '.png',
+        '.jpg',
+        '.jpeg',
+        '.gif',
+        '.svg',
+        '.ico',
+        '.eot',
+        '.ttf',
+        '.woff',
+        '.woff2',
+      ],
     }))
     .pipe(gulp.dest(paths.build))
     .pipe(revAll.manifestFile())


### PR DESCRIPTION
The updated gulp revision task now uses a whitelist so this adds the
files we're revisioning to that whitelist so they appear in the
manifest file used to serve the assets.