### PR TITLE
Use strict mode to allow block-scoped declarations

### DIFF
--- a/gulp/tasks/serve.js
+++ b/gulp/tasks/serve.js
@@ -1,3 +1,7 @@
+/* eslint-disable strict */
+
+'use strict';
+
 const gulp = require('gulp');
 const nodemon = require('gulp-nodemon');
 

--- a/test/acceptance/wdio.conf.js
+++ b/test/acceptance/wdio.conf.js
@@ -1,3 +1,7 @@
+/* eslint-disable strict */
+
+'use strict';
+
 const fs = require('fs');
 const del = require('del');
 const request = require('request');


### PR DESCRIPTION
Removing this caused an error in the deployment task so adding back in.