### PR TITLE
Add type 2 diabetes links back to Choices pages

### DIFF
--- a/content/conditions/type-2-diabetes/check-if-you-have-it/manifest.json
+++ b/content/conditions/type-2-diabetes/check-if-you-have-it/manifest.json
@@ -2,7 +2,7 @@
   "layout": "content-simple",
   "guide": true,
   "title": "Check if you have it",
-  "choicesOrigin": "",
+  "choicesOrigin": "conditions/Diabetes-type2/Pages/Introduction.aspx",
   "main": [
     {
       "type": "content_block",

--- a/content/conditions/type-2-diabetes/finding-help-and-support/manifest.json
+++ b/content/conditions/type-2-diabetes/finding-help-and-support/manifest.json
@@ -2,7 +2,7 @@
   "layout": "content-simple",
   "guide": true,
   "title": "Finding help and support",
-  "choicesOrigin": "",
+  "choicesOrigin": "conditions/Diabetes-type2/Pages/Introduction.aspx",
   "main": [
     {
       "type": "content_block",

--- a/content/conditions/type-2-diabetes/food-and-keeping-active/manifest.json
+++ b/content/conditions/type-2-diabetes/food-and-keeping-active/manifest.json
@@ -2,7 +2,7 @@
   "layout": "content-simple",
   "guide": true,
   "title": "Food and keeping active",
-  "choicesOrigin": "",
+  "choicesOrigin": "conditions/Diabetes-type2/Pages/Introduction.aspx",
   "main": [
     {
       "type": "content_block",

--- a/content/conditions/type-2-diabetes/getting-diagnosed/manifest.json
+++ b/content/conditions/type-2-diabetes/getting-diagnosed/manifest.json
@@ -2,7 +2,7 @@
   "layout": "content-simple",
   "guide": true,
   "title": "Getting diagnosed",
-  "choicesOrigin": "",
+  "choicesOrigin": "conditions/Diabetes-type2/Pages/Diagnosis.aspx ",
   "main": [
     {
       "type": "content_block",

--- a/content/conditions/type-2-diabetes/going-for-regular-check-ups/manifest.json
+++ b/content/conditions/type-2-diabetes/going-for-regular-check-ups/manifest.json
@@ -2,7 +2,7 @@
   "layout": "content-simple",
   "guide": true,
   "title": "Going for regular check ups",
-  "choicesOrigin": "",
+  "choicesOrigin": "conditions/Diabetes-type2/Pages/Living-with.aspx",
   "main": [
     {
       "type": "content_block",

--- a/content/conditions/type-2-diabetes/health-problems/manifest.json
+++ b/content/conditions/type-2-diabetes/health-problems/manifest.json
@@ -2,7 +2,7 @@
   "layout": "content-simple",
   "guide": true,
   "title": "Health problems",
-  "choicesOrigin": "",
+  "choicesOrigin": "conditions/Diabetes-type2/Pages/Complications.aspx",
   "main": [
     {
       "type": "content_block",

--- a/content/conditions/type-2-diabetes/understanding-medication/manifest.json
+++ b/content/conditions/type-2-diabetes/understanding-medication/manifest.json
@@ -2,7 +2,7 @@
   "layout": "content-simple",
   "guide": true,
   "title": "Understanding medication",
-  "choicesOrigin": "",
+  "choicesOrigin": "conditions/Diabetes-type2/Pages/Treatment.aspx",
   "main": [
     {
       "type": "content_block",


### PR DESCRIPTION
This creates the link back to NHS Choices pages for the Type 2 diabetes content.