### PR TITLE
Add timeout to feedback API and persist comment

### DIFF
--- a/app/middleware/feedback.js
+++ b/app/middleware/feedback.js
@@ -16,17 +16,17 @@ module.exports = () => {
 
     if (isPost && isFeedback && !config.feedbackApi.disabled) {
       req.checkBody('feedback-form-comments').notEmpty();
+      req.sanitizeBody('feedback-form-comments');
+      req.sanitizeBody('feedback-form-path');
 
       const errors = req.validationErrors();
       if (errors) {
         res.locals.FEEDBACKFORM.outcome = 'failure';
         res.locals.FEEDBACKFORM.errorType = 'submission';
         res.locals.FEEDBACKFORM.errors = errors;
+        res.locals.FEEDBACKFORM.data = req.body;
         next();
       } else {
-        req.sanitizeBody('feedback-form-comments');
-        req.sanitizeBody('feedback-form-path');
-
         const formData = {
           ip: requestIp.getClientIp(req),
           comment: req.body['feedback-form-comments'],
@@ -42,6 +42,7 @@ module.exports = () => {
             logger.error(error);
             res.locals.FEEDBACKFORM.outcome = 'failure';
             res.locals.FEEDBACKFORM.errorType = 'server';
+            res.locals.FEEDBACKFORM.data = req.body;
             next();
           });
       }

--- a/app/views/_includes/feedback-form.nunjucks
+++ b/app/views/_includes/feedback-form.nunjucks
@@ -29,7 +29,7 @@
         </label>
         <div class="grid-row">
           <div class="column__two-thirds">
-            <textarea name="feedback-form-comments" id="feedback-form-comments" {% if FEEDBACKFORM.outcome == "failure" %}class="error"{% endif %} rows="4"></textarea>
+            <textarea name="feedback-form-comments" id="feedback-form-comments" {% if FEEDBACKFORM.outcome == "failure" %}class="error"{% endif %} rows="4">{{ FEEDBACKFORM.data['feedback-form-comments'] }}</textarea>
           </div>
         </div>
 

--- a/config/config.js
+++ b/config/config.js
@@ -31,6 +31,7 @@ module.exports = {
     jobNum: process.env.TRAVIS_JOB_NUMBER,
   },
   feedbackApi: {
+    timeout: process.env.FEEDBACK_TIMEOUT || 5000,
     disabled: process.env.DISABLE_FEEDBACK || false,
     baseUrl: process.env.FEEDBACK_API_BASEURL,
     apiKey: process.env.FEEDBACK_API_KEY,

--- a/lib/feedback-api.js
+++ b/lib/feedback-api.js
@@ -25,6 +25,7 @@ FeedbackApi.prototype.sendComment = function sendComment(formData) {
 FeedbackApi.prototype.send = function send(data) {
   return new Promise((resolve, reject) => {
     request({
+      timeout: config.feedbackApi.timeout,
       method: 'POST',
       uri: this.API_BASEURL,
       headers: {

--- a/test/unit/lib/feedback-api.js
+++ b/test/unit/lib/feedback-api.js
@@ -4,6 +4,7 @@ const config = {
   feedbackApi: {
     baseUrl: 'http://api-baseurl.com/',
     apiKey: 'APIKEY123456789',
+    timeout: 5000,
   },
 };
 const fakeTime = moment('2016-06-24').tz('Europe/London').startOf('day');
@@ -43,6 +44,7 @@ describe('feedback api library', () => {
           'Ocp-Apim-Subscription-Key': config.feedbackApi.apiKey,
         },
         form: formData,
+        timeout: 5000,
       });
       return send.should.eventually.deep.equal(formData);
     });


### PR DESCRIPTION
This adds a timeout to the feedback API call that can be changed
per environment.

It also persists the comment the user has entered through any errors.