### PR TITLE
Tidy spacing on footer lists

### DIFF
--- a/assets/stylesheets/components/_inline-list.scss
+++ b/assets/stylesheets/components/_inline-list.scss
@@ -4,10 +4,9 @@
 }
 
 .inline-list--item {
-  margin: 0;
-
   @include media(tablet) {
     display: inline;
+    margin-top: 0;
   }
 }
 

--- a/assets/stylesheets/units/_lists.scss
+++ b/assets/stylesheets/units/_lists.scss
@@ -19,7 +19,8 @@ dl {
 }
 
 .local-header,
-.page-section {
+.page-section,
+.global-footer {
   li + li {
     margin-top: $baseline-grid-unit * 2;
   }


### PR DESCRIPTION
This tidies the spacing of inline lists on smaller devices. 

**Before:**
No spacing between elements when on mobile

![before](https://cloud.githubusercontent.com/assets/3327997/19523492/9d98654c-9612-11e6-9303-344eaf16cff0.png)

**After:**
Uses same spacing as lists within rest of layout

![after](https://cloud.githubusercontent.com/assets/3327997/19523503/a26afcc4-9612-11e6-9daa-a3073a8eb004.png)
