### PR TITLE
Don't restart server on frontend asset changes

### DIFF
--- a/gulp/tasks/serve.js
+++ b/gulp/tasks/serve.js
@@ -13,6 +13,10 @@ gulp.task('serve', (cb) => {
   return nodemon({
     script: 'app.js',
     ext: 'js nunjucks',
+    ignore: [
+      './assets',
+      './tmp',
+    ],
   }).on('start', () => {
     // to avoid nodemon being started multiple times
     if (!started) {


### PR DESCRIPTION
Prevents double server restart when changing files within `assets/`