### PR TITLE
Change feedback data capture

### DIFF
--- a/app/middleware/feedback.js
+++ b/app/middleware/feedback.js
@@ -16,10 +16,12 @@ module.exports = () => {
 
     if (isPost && isFeedback && !config.feedbackApi.disabled) {
       req.checkBody('feedback-form-comments').notEmpty();
+      req.checkBody('feedback-form-found').notEmpty();
       req.sanitizeBody('feedback-form-comments');
+      req.sanitizeBody('feedback-form-found');
       req.sanitizeBody('feedback-form-path');
 
-      const errors = req.validationErrors();
+      const errors = req.validationErrors(true);
       if (errors) {
         res.locals.FEEDBACKFORM.outcome = 'failure';
         res.locals.FEEDBACKFORM.errorType = 'submission';
@@ -30,6 +32,7 @@ module.exports = () => {
         const formData = {
           ip: requestIp.getClientIp(req),
           comment: req.body['feedback-form-comments'],
+          found: req.body['feedback-form-found'],
           path: req.body['feedback-form-path'],
         };
 

--- a/app/views/_includes/feedback-form.nunjucks
+++ b/app/views/_includes/feedback-form.nunjucks
@@ -13,8 +13,19 @@
               <div class="callout callout__error" role="group" aria-labelledby="error-summary" tabindex="-1">
                 <p id="error-summary">
                   {% if FEEDBACKFORM.errorType == "submission" %}
-                    Sorry, the feedback area was empty. <a href="#feedback-form-comments">
-                      Please make sure to add your comments about this page.</a>
+                    Sorry, the feedback wasn't complete. Please make sure to tell us
+
+                    {% if FEEDBACKFORM.errors['feedback-form-comments'] %}
+                      <a href="#feedback-form-comments">what you were looking for{{ '.' if not FEEDBACKFORM.errors['feedback-form-found'] }}</a>{{ ',' if FEEDBACKFORM.errors['feedback-form-found'] }}
+                    {% endif %}
+
+                    {% if FEEDBACKFORM.errors['feedback-form-found'] and FEEDBACKFORM.errors['feedback-form-comments'] %}
+                      and
+                    {% endif %}
+
+                    {% if FEEDBACKFORM.errors['feedback-form-found'] %}
+                      <a href="#looking-for-group">if you found it.</a>
+                    {% endif %}
                   {% elif FEEDBACKFORM.errorType == "server" %}
                     Sorry, there’s been an error, <a href="#feedback-form-comments">please try again.</a>
                   {% endif %}
@@ -25,13 +36,65 @@
         {% endif %}
 
         <label for="feedback-form-comments" class="form-label form-label__large">
-          What’s useful about this page? What’s missing?
+          What were you looking for?
         </label>
         <div class="grid-row">
           <div class="column__two-thirds">
-            <textarea name="feedback-form-comments" id="feedback-form-comments" {% if FEEDBACKFORM.outcome == "failure" %}class="error"{% endif %} rows="4">{{ FEEDBACKFORM.data['feedback-form-comments'] }}</textarea>
+            <textarea
+              name="feedback-form-comments"
+              id="feedback-form-comments"
+              rows="4"
+              {% if FEEDBACKFORM.errors['feedback-form-comments'] %}
+                class="error"
+              {% endif %}
+            >{{ FEEDBACKFORM.data['feedback-form-comments'] }}</textarea>
           </div>
         </div>
+
+        <fieldset>
+          <legend class="form-label form-label__large" id="looking-for-group">
+            Did you find what you were looking for?
+          </legend>
+          <div class="grid-row">
+            <div class="column__two-thirds">
+              <label class="selection-button selection-button__inline selection-button__radio{{ ' has-error' if FEEDBACKFORM.errors['feedback-form-found'] }}">
+                <input
+                  type="radio"
+                  name="feedback-form-found"
+                  value="Yes"
+                  class="selection-button--input"
+                  {% if FEEDBACKFORM.data['feedback-form-found'] == 'Yes' %}
+                    checked=checked
+                  {% endif %}>
+                Yes
+              </label>
+
+              <label class="selection-button selection-button__inline selection-button__radio{{ ' has-error' if FEEDBACKFORM.errors['feedback-form-found'] }}">
+                <input
+                  type="radio"
+                  name="feedback-form-found"
+                  value="No"
+                  class="selection-button--input"
+                  {% if FEEDBACKFORM.data['feedback-form-found'] == 'No' %}
+                    checked=checked
+                  {% endif %}>
+                No
+              </label>
+
+              <label class="selection-button selection-button__inline selection-button__radio{{ ' has-error' if FEEDBACKFORM.errors['feedback-form-found'] }}">
+                <input
+                  type="radio"
+                  name="feedback-form-found"
+                  value="Partially"
+                  class="selection-button--input"
+                  {% if FEEDBACKFORM.data['feedback-form-found'] == 'Partially' %}
+                    checked=checked
+                  {% endif %}>
+                Partially
+              </label>
+            </div>
+          </div>
+        </fieldset>
 
         <button type="submit" class="button" data-analytics="DCSext.GeneralLinks,SendFeedback)">Send feedback</button>
         <button type="reset" class="button button__cancel" data-analytics="DCSext.GeneralLinks,CancelFeedback)">Cancel</button>

--- a/app/views/_includes/feedback-form.nunjucks
+++ b/app/views/_includes/feedback-form.nunjucks
@@ -96,8 +96,8 @@
           </div>
         </fieldset>
 
-        <button type="submit" class="button" data-analytics="DCSext.GeneralLinks,SendFeedback)">Send feedback</button>
-        <button type="reset" class="button button__cancel" data-analytics="DCSext.GeneralLinks,CancelFeedback)">Cancel</button>
+        <button type="submit" class="button" data-analytics="event" data-analytics-type="SendFeedback">Send feedback</button>
+        <button type="reset" class="button button__cancel" data-analytics="event" data-analytics-type="CancelFeedback">Cancel</button>
 
         <input type="hidden" name="feedback-form-path" value="{{ FEEDBACKFORM.path }}">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">

--- a/app/views/_includes/new-site-message.nunjucks
+++ b/app/views/_includes/new-site-message.nunjucks
@@ -2,10 +2,10 @@
   <p class="notification-banner--inner">
     This is a new page.
     {% if feedback and not FEEDBACKFORM.disabled and FEEDBACKFORM.outcome != "success"  %}
-      <a href="#page-feedback" class="js-feedback-toggle" data-analytics="DCSext.GeneralLinks,TellUsWhatYouThink">Tell us what you think</a> or go
+      <a href="#page-feedback" class="js-feedback-toggle" data-analytics="event" data-analytics-type="TellUsWhatYouThink">Tell us what you think</a> or go
     {% else %}
       Go
     {% endif %}
-    <a href="http://www.nhs.uk/{{ choicesOrigin }}" data-analytics="DCSext.GeneralLinks,BackToChoices">back to NHS Choices.</a>
+    <a href="http://www.nhs.uk/{{ choicesOrigin }}" data-analytics="external">back to NHS Choices.</a>
   </p>
 </div>

--- a/app/views/elements.nunjucks
+++ b/app/views/elements.nunjucks
@@ -104,6 +104,86 @@
         <li><q>Quotation</q></li>
         <li><abbr title="An abbreviation">Abbreviation</abbr></li>
       </ul>
+
+      <form>
+        <h2>Basic form elements</h2>
+
+        <fieldset>
+          <legend class="form-label">Stacked radio buttons</legend>
+
+          <div class="form-group">
+            <label for="radio-1" class="selection-button selection-button__radio">
+              <input id="radio-1" type="radio" name="radio-group" value="radio-1" class="selection-button--input">
+              Radio 1
+            </label>
+            <label for="radio-2" class="selection-button selection-button__radio">
+              <input id="radio-2" type="radio" name="radio-group" value="radio-2" class="selection-button--input">
+              Radio 2
+            </label>
+            <label for="radio-3" class="selection-button selection-button__radio">
+              <input id="radio-3" type="radio" name="radio-group" value="radio-3" class="selection-button--input">
+              Radio 3
+            </label>
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend>Inline radio buttons</legend>
+
+          <div class="form-group">
+            <label for="inline-radio-1" class="selection-button selection-button__inline selection-button__radio">
+              <input id="inline-radio-1" type="radio" name="inline-radio-group" value="inline-radio-1" class="selection-button--input">
+              Radio 1
+            </label>
+            <label for="inline-radio-2" class="selection-button selection-button__inline selection-button__radio">
+              <input id="inline-radio-2" type="radio" name="inline-radio-group" value="inline-radio-2" class="selection-button--input">
+              Radio 2
+            </label>
+            <label for="inline-radio-3" class="selection-button selection-button__inline selection-button__radio">
+              <input id="inline-radio-3" type="radio" name="inline-radio-group" value="inline-radio-3" class="selection-button--input">
+              Radio 3
+            </label>
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend>Stacked checkboxes</legend>
+
+          <div class="form-group">
+            <label for="checkbox-1" class="selection-button selection-button__checkbox">
+              <input id="checkbox-1" type="checkbox" name="checkbox-group" value="checkbox-1" class="selection-button--input">
+              Checkbox 1
+            </label>
+            <label for="checkbox-2" class="selection-button selection-button__checkbox">
+              <input id="checkbox-2" type="checkbox" name="checkbox-group" value="checkbox-2" class="selection-button--input">
+              Checkbox 2
+            </label>
+            <label for="checkbox-3" class="selection-button selection-button__checkbox">
+              <input id="checkbox-3" type="checkbox" name="checkbox-group" value="checkbox-3" class="selection-button--input">
+              Checkbox 3
+            </label>
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend>Inline checkboxes</legend>
+
+          <div class="form-group">
+            <label for="inline-checkbox-1" class="selection-button selection-button__inline selection-button__checkbox">
+              <input id="inline-checkbox-1" type="checkbox" name="inline-checkbox-group" value="inline-checkbox-1" class="selection-button--input">
+              Checkbox 1
+            </label>
+            <label for="inline-checkbox-2" class="selection-button selection-button__inline selection-button__checkbox">
+              <input id="inline-checkbox-2" type="checkbox" name="inline-checkbox-group" value="inline-checkbox-2" class="selection-button--input">
+              Checkbox 2
+            </label>
+            <label for="inline-checkbox-3" class="selection-button selection-button__inline selection-button__checkbox">
+              <input id="inline-checkbox-3" type="checkbox" name="inline-checkbox-group" value="inline-checkbox-3" class="selection-button--input">
+              Checkbox 3
+            </label>
+          </div>
+        </fieldset>
+      </form>
     </div>
   </div>
 {% endblock %}

--- a/assets/javascripts/modules/analytics.js
+++ b/assets/javascripts/modules/analytics.js
@@ -78,7 +78,17 @@ Analytics.prototype._getEventData = function _getEventData(e) {
       name = `${this.wtPrefix}Pagination`;
       value = $el.attr('rel');
       break;
+    case 'external':
+      name = `${this.wtPrefix}ExternalLinks`;
+      value = $el.attr('href');
+      break;
+    case 'event':
+      name = `${this.wtPrefix}Event`;
+      value = $el.prop('tagName');
+      break;
     default:
+      name = `${this.wtPrefix}GeneralLinks`;
+      value = component;
       break;
   }
 

--- a/assets/javascripts/modules/label-focus.js
+++ b/assets/javascripts/modules/label-focus.js
@@ -1,0 +1,38 @@
+const $ = require('jquery');
+
+const LabelFocus = function LabelFocus() {
+  this.el = '.selection-button';
+  this.className = 'is-focused';
+};
+
+LabelFocus.prototype.init = function init() {
+  this.cacheEls();
+  this.bindEvents();
+};
+
+LabelFocus.prototype.cacheEls = function cacheEls() {
+  this.$body = $('body');
+};
+
+LabelFocus.prototype.bindEvents = function bindEvents() {
+  const delegate = `${this.el} input[type=radio], ${this.el} input[type=checkbox]`;
+
+  this.$body
+    .on('focus.LabelFocus', delegate, $.proxy(this.onFocus, this))
+    .on('blur.LabelFocus', delegate, $.proxy(this.onBlur, this));
+};
+
+LabelFocus.prototype.onFocus = function onFocus(e) {
+  $(e.currentTarget).parent('label').addClass(this.className);
+};
+
+LabelFocus.prototype.onBlur = function onBlur(e) {
+  $(e.currentTarget).parent('label').removeClass(this.className);
+};
+
+LabelFocus.prototype.destroy = function destroy() {
+  this.$body
+    .off('change.LabelFocus');
+};
+
+module.exports = new LabelFocus();

--- a/assets/javascripts/modules/label-select.js
+++ b/assets/javascripts/modules/label-select.js
@@ -1,0 +1,52 @@
+const $ = require('jquery');
+
+const LabelSelect = function LabelSelect() {
+  this.el = '.selection-button';
+  this.className = 'is-selected';
+  this.delegateSelector = `${this.el} input[type=radio], ${this.el} input[type=checkbox]`;
+};
+
+LabelSelect.prototype.init = function init() {
+  this.cacheEls();
+  this.bindEvents();
+  this.render();
+};
+
+LabelSelect.prototype.cacheEls = function cacheEls() {
+  this.$body = $('body');
+};
+
+LabelSelect.prototype.bindEvents = function bindEvents() {
+  this.$body
+    .on('change.LabelSelect', this.delegateSelector, $.proxy(this.onChange, this));
+};
+
+LabelSelect.prototype.onChange = function onChange(e) {
+  const $el = $(e.currentTarget);
+  const $parent = $el.parent('label');
+
+  // clear out all other selections on radio elements
+  if ($el.attr('type') === 'radio') {
+    $(`[name=${$el.attr('name')}]`).parent('label').removeClass(this.className);
+  }
+
+  // set state class on check
+  if ($el.is(':checked')) {
+    $parent.addClass(this.className);
+  } else {
+    $parent.removeClass(this.className);
+  }
+};
+
+LabelSelect.prototype.render = function render() {
+  this.$body.find(this.delegateSelector).filter(':checked').each((i, el) => {
+    $(el).parent().addClass(this.className);
+  });
+};
+
+LabelSelect.prototype.destroy = function destroy() {
+  this.$body
+    .off('change.LabelSelect');
+};
+
+module.exports = new LabelSelect();

--- a/assets/javascripts/nhsuk.js
+++ b/assets/javascripts/nhsuk.js
@@ -1,7 +1,11 @@
 const cookieMessage = require('./modules/cookie-message');
 const feedbackForm = require('./modules/feedback-form');
 const analytics = require('./modules/analytics');
+const labelFocus = require('./modules/label-focus');
+const labelSelect = require('./modules/label-select');
 
 cookieMessage('global-cookies-banner');
 feedbackForm.init();
 analytics.init();
+labelFocus.init();
+labelSelect.init();

--- a/assets/stylesheets/components/_callout.scss
+++ b/assets/stylesheets/components/_callout.scss
@@ -1,6 +1,10 @@
 .callout {
   @include element-padding;
   background-color: $white;
+
+  &:focus {
+    outline: 3px solid $focus-colour;
+  }
 }
 
   .callout--inner {

--- a/assets/stylesheets/components/_selection-button.scss
+++ b/assets/stylesheets/components/_selection-button.scss
@@ -1,0 +1,123 @@
+$_border-colour: $grey-2;
+$_border-width: 2px;
+$_element-size: 38px;
+$_radio-size: 20px;
+$_radio-spacing: ($_element-size - $_radio-size) / 2;
+
+.selection-button {
+  @include core-font(20);
+  cursor: pointer;
+  display: block;
+  min-height: $_element-size;
+  padding: 2px 0 2px 50px;
+  position: relative;
+  width: auto;
+}
+
+  .selection-button--input {
+    cursor: pointer;
+    height: $_element-size;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: $_element-size;
+
+    @if ($is-ie == false) or ($ie-version == 9) {
+      // scss-lint:disable SelectorFormat
+      .js-enabled & {
+        @extend %visuallyhidden;
+      }
+      // scss-lint:enable SelectorFormat
+    }
+  }
+
+.selection-button__inline {
+  @include media(tablet) {
+    float: left;
+
+    + .selection-button__inline {
+      margin-left: $default-spacing-unit * 2;
+      margin-top: 0;
+    }
+  }
+}
+
+.selection-button__radio {
+  &::before {
+    background: $white;
+    border: $_border-width solid $_border-colour;
+    border-radius: 50%;
+    content: "";
+    height: $_element-size;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: $_element-size;
+  }
+
+  &::after {
+    background: currentColor;
+    border-radius: 50%;
+    content: "";
+    filter: alpha(opacity = 0);
+    height: $_radio-size;
+    left: $_radio-spacing;
+    opacity: 0;
+    position: absolute;
+    top: $_radio-spacing;
+    width: $_radio-size;
+    zoom: 1;
+  }
+}
+
+.selection-button__checkbox {
+  &::before {
+    background: $white;
+    border: $_border-width solid $_border-colour;
+    content: "";
+    height: $_element-size;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: $_element-size;
+  }
+
+  &::after {
+    @include rotate(-45);
+    background: transparent;
+    border: solid;
+    border-width: 0 0 5px 5px;
+    content: "";
+    filter: alpha(opacity = 0);
+    height: 12px;
+    left: 8px;
+    opacity: 0;
+    position: absolute;
+    top: 10px;
+    width: 22px;
+    zoom: 1;
+  }
+}
+
+.selection-button__radio,
+.selection-button__checkbox {
+  &.is-focused {
+    &::before {
+      @include box-shadow(0 0 0 3px $focus-colour);
+    }
+  }
+
+  &.is-selected {
+    &::after {
+      filter: alpha(opacity = 100);
+      opacity: 1;
+      zoom: 1;
+    }
+  }
+
+  &.has-error {
+    &::before {
+      border-color: $red;
+    }
+  }
+}

--- a/assets/stylesheets/environment/tools/mixins/_css3.scss
+++ b/assets/stylesheets/environment/tools/mixins/_css3.scss
@@ -11,3 +11,17 @@
      -moz-background-clip: $clip; // Firefox 2.0 to 3.6
           background-clip: $clip;
 }
+
+@mixin box-shadow($shadow) {
+  -webkit-box-shadow: $shadow; // Chrome 4.0 to 9.0, Safari 3.1 to 5.0, Mobile Safari 3.2 to 4.3, Android Browser 2.1 to 3.0
+     -moz-box-shadow: $shadow; // Firefox 3.5 to 3.6
+          box-shadow: $shadow;
+}
+
+@mixin rotate($deg) {
+  -webkit-transform: rotate(#{$deg}deg);
+     -moz-transform: rotate(#{$deg}deg);
+      -ms-transform: rotate(#{$deg}deg);
+       -o-transform: rotate(#{$deg}deg);
+          transform: rotate(#{$deg}deg);
+}

--- a/assets/stylesheets/nhsuk.scss
+++ b/assets/stylesheets/nhsuk.scss
@@ -50,4 +50,5 @@
 @import "components/local-header";
 @import "components/notification-banner";
 @import "components/section-unit";
+@import "components/selection-button";
 @import "components/skiplinks";

--- a/assets/stylesheets/units/_buttons.scss
+++ b/assets/stylesheets/units/_buttons.scss
@@ -14,8 +14,12 @@
   width: 100%;
 
   @include media(tablet) {
-    margin-right: $default-spacing-unit * 2;
+    margin-right: $default-spacing-unit;
     width: auto;
+  }
+
+  @include media(desktop) {
+    margin-right: $default-spacing-unit * 2;
   }
 
   &:link,

--- a/assets/stylesheets/units/_forms.scss
+++ b/assets/stylesheets/units/_forms.scss
@@ -1,3 +1,27 @@
+fieldset {
+  border: 0;
+  margin: 0;
+  min-width: 0;
+  padding: 0;
+
+  body:not(:-moz-handler-blocked) & {
+    display: table-cell;
+  }
+}
+
+legend {
+  @include core-font(20);
+  display: table;
+  padding: 0;
+
+  // In Webkit, the bottom margin of a legend and the top margin
+  // of the next element don't overlap, which they should. This
+  // addresses that by discarding the top margin of the next element
+  + * {
+    -webkit-margin-top-collapse: separate;
+  }
+}
+
 textarea {
   @include core-font(20);
 

--- a/test/acceptance/specs/feedback.js
+++ b/test/acceptance/specs/feedback.js
@@ -36,7 +36,7 @@ describe('feedback mechanism', () => {
 
       FeedbackPage.errorSummary.waitForExist();
       FeedbackPage.errorSummary.isVisible().should.be.true;
-      FeedbackPage.errorSummary.getText().should.contain('feedback area was empty');
+      FeedbackPage.errorSummary.getText().should.contain('feedback wasn\'t complete');
       FeedbackPage.comment.getAttribute('class').should.contain('error');
     });
 


### PR DESCRIPTION
Change the feedback wording to be more focused on what the user was looking for rather than what it missing. This also added a new field to capture about whether they feel they found what they were looking for.

Part of this change involved changing the error handling to support both fields being empty and creating a new pattern around radios/checkboxes.