### PR TITLE
Bugfix: Fixes non-js layout of selection buttons

### DIFF
--- a/assets/stylesheets/components/_selection-button.scss
+++ b/assets/stylesheets/components/_selection-button.scss
@@ -1,3 +1,5 @@
+// scss-lint:disable SelectorFormat NestingDepth
+
 $_border-colour: $grey-2;
 $_border-width: 2px;
 $_element-size: 38px;
@@ -9,25 +11,29 @@ $_radio-spacing: ($_element-size - $_radio-size) / 2;
   cursor: pointer;
   display: block;
   min-height: $_element-size;
-  padding: 2px 0 2px 50px;
+  padding: 2px 0;
   position: relative;
-  width: auto;
+
+  .js-enabled & {
+    padding-left: 50px;
+    width: auto;
+  }
 }
 
   .selection-button--input {
     cursor: pointer;
-    height: $_element-size;
-    left: 0;
-    position: absolute;
-    top: 0;
-    width: $_element-size;
+    margin-right: 10px;
 
     @if ($is-ie == false) or ($ie-version == 9) {
-      // scss-lint:disable SelectorFormat
       .js-enabled & {
         @extend %visuallyhidden;
+        height: $_element-size;
+        left: 0;
+        margin-right: 0;
+        position: absolute;
+        top: 0;
+        width: $_element-size;
       }
-      // scss-lint:enable SelectorFormat
     }
   }
 
@@ -42,82 +48,89 @@ $_radio-spacing: ($_element-size - $_radio-size) / 2;
   }
 }
 
-.selection-button__radio {
-  &::before {
-    background: $white;
-    border: $_border-width solid $_border-colour;
-    border-radius: 50%;
-    content: "";
-    height: $_element-size;
-    left: 0;
-    position: absolute;
-    top: 0;
-    width: $_element-size;
-  }
 
-  &::after {
-    background: currentColor;
-    border-radius: 50%;
-    content: "";
-    filter: alpha(opacity = 0);
-    height: $_radio-size;
-    left: $_radio-spacing;
-    opacity: 0;
-    position: absolute;
-    top: $_radio-spacing;
-    width: $_radio-size;
-    zoom: 1;
+.selection-button__radio {
+  .js-enabled & {
+    &::before {
+      background: $white;
+      border: $_border-width solid $_border-colour;
+      border-radius: 50%;
+      content: "";
+      height: $_element-size;
+      left: 0;
+      position: absolute;
+      top: 0;
+      width: $_element-size;
+    }
+
+    &::after {
+      background: currentColor;
+      border-radius: 50%;
+      content: "";
+      filter: alpha(opacity = 0);
+      height: $_radio-size;
+      left: $_radio-spacing;
+      opacity: 0;
+      position: absolute;
+      top: $_radio-spacing;
+      width: $_radio-size;
+      zoom: 1;
+    }
   }
 }
 
 .selection-button__checkbox {
-  &::before {
-    background: $white;
-    border: $_border-width solid $_border-colour;
-    content: "";
-    height: $_element-size;
-    left: 0;
-    position: absolute;
-    top: 0;
-    width: $_element-size;
-  }
+  .js-enabled & {
+    &::before {
+      background: $white;
+      border: $_border-width solid $_border-colour;
+      content: "";
+      height: $_element-size;
+      left: 0;
+      position: absolute;
+      top: 0;
+      width: $_element-size;
+    }
 
-  &::after {
-    @include rotate(-45);
-    background: transparent;
-    border: solid;
-    border-width: 0 0 5px 5px;
-    content: "";
-    filter: alpha(opacity = 0);
-    height: 12px;
-    left: 8px;
-    opacity: 0;
-    position: absolute;
-    top: 10px;
-    width: 22px;
-    zoom: 1;
+    &::after {
+      @include rotate(-45);
+      background: transparent;
+      border: solid;
+      border-width: 0 0 5px 5px;
+      content: "";
+      filter: alpha(opacity = 0);
+      height: 12px;
+      left: 8px;
+      opacity: 0;
+      position: absolute;
+      top: 10px;
+      width: 22px;
+      zoom: 1;
+    }
   }
 }
 
 .selection-button__radio,
 .selection-button__checkbox {
-  &.is-focused {
-    &::before {
-      @include box-shadow(0 0 0 3px $focus-colour);
+  .js-enabled & {
+    &.is-focused {
+      &::before {
+        @include box-shadow(0 0 0 3px $focus-colour);
+      }
     }
-  }
 
-  &.is-selected {
-    &::after {
-      filter: alpha(opacity = 100);
-      opacity: 1;
-      zoom: 1;
+    &.is-selected {
+      &::after {
+        filter: alpha(opacity = 100);
+        opacity: 1;
+        zoom: 1;
+      }
     }
-  }
 
-  &.has-error {
-    &::before {
-      border-color: $red;
+    &.has-error {
+      &::before {
+        border-color: $red;
+      }
     }
   }
 }


### PR DESCRIPTION
Currently before and after elements were being styled even when
javascript is not enabled/loaded meaning the default browser elements
would be hidden.

This ensures the style is only applied when the browser understands
javascript is available.