### PR TITLE
Pin webpack to avoid UglifyJS being updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "request-ip": "~1.2.2",
     "require-dir": "~0.3.0",
     "serve-favicon": "~2.3.0",
-    "webpack": "~1.13.2",
+    "webpack": "1.13.2",
     "winston": "~2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Webpack 1.3.3 updated Uglify to 2.74 which now includes the --screw-ie8
flag by default:
https://github.com/mishoo/UglifyJS2/commit/02c638209ee22816b1324ff0c0f47b27db1336af

This now throws an error in IE8 builds which we don't want so for now
we're pinning the package - will need to find a better solution.