### PR TITLE
Update html background colour to match footer

### DIFF
--- a/assets/stylesheets/environment/generic/_shared.scss
+++ b/assets/stylesheets/environment/generic/_shared.scss
@@ -4,7 +4,7 @@ html, body, button, input, table, td, th {
 }
 
 html {
-  background-color: $grey-3;
+  background-color: $nhs-blue;
 }
 
 body {


### PR DESCRIPTION
During the global footer update the html background colour was missed
so if content doesn't fill the browser height it will display a
different colour