### PR TITLE
Update codeclimate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -11,3 +11,13 @@ engines:
       - javascript
   nodesecurity:
     enabled: true
+ratings:
+  paths:
+  - "app/**"
+  - "config/**"
+  - "lib/**"
+  - "app.js"
+exclude_paths:
+- "**/vendor/"
+- "test/"
+- "gulp/"


### PR DESCRIPTION
Ignore vendor assets and tests from codeclimate scans and add
paths to files to be rated.