### PR TITLE
Allow content-api request to support querystrings and not 404

### DIFF
--- a/app/controllers/redirect.js
+++ b/app/controllers/redirect.js
@@ -1,5 +1,8 @@
+const parseurl = require('parseurl');
+
 function index(req, res) {
-  res.redirect('/');
+  const parsedUrl = parseurl.original(req);
+  res.redirect(`/${parsedUrl.search || ''}`);
 }
 
 module.exports = {

--- a/app/middleware/content-api.js
+++ b/app/middleware/content-api.js
@@ -1,8 +1,10 @@
 const contentApi = require('../../lib/content-api');
+const parseurl = require('parseurl');
 
 module.exports = () => {
   return (req, res, next) => {
-    const slug = req.originalUrl.replace(/^\//, '') || 'index';
+    const parsedUrl = parseurl.original(req);
+    const slug = parsedUrl.pathname.replace(/^\//, '') || 'index';
     const record = contentApi.getRecord(`${slug}`);
     let layout = slug;
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "normalize.css": "~4.1.1",
     "nunjucks": "~2.5.2",
     "nunjucks-markdown": "~2.0.0",
+    "parseurl": "^1.3.1",
     "picturefill": "~3.0.2",
     "pre-commit": "~1.1.3",
     "request": "~2.75.0",

--- a/test/unit/controllers/redirect.test.js
+++ b/test/unit/controllers/redirect.test.js
@@ -11,8 +11,8 @@ describe('Redirect controller', () => {
   });
 
   describe('#index', () => {
-    describe('a route is called', () => {
-      it('redirect to the site root', (done) => {
+    describe('a route is called without a querystring', () => {
+      it('redirect to the site root without a querystring', (done) => {
         const res = {
           redirect: (path) => {
             path.should.equal('/');
@@ -20,7 +20,24 @@ describe('Redirect controller', () => {
           },
         };
 
-        redirectController.index({}, res);
+        redirectController.index({
+          originalUrl: '/something',
+        }, res);
+      });
+    });
+
+    describe('a route is called with a querystring', () => {
+      it('redirect to the site root including the querystring', (done) => {
+        const res = {
+          redirect: (path) => {
+            path.should.equal('/?foo=bar');
+            done();
+          },
+        };
+
+        redirectController.index({
+          originalUrl: '/something?foo=bar',
+        }, res);
       });
     });
   });


### PR DESCRIPTION
If a querystring was added to the URL it would return a 404 which is not the correct behaviour. 

This was happening because we were looking for the full url in the views or content folder. 

This change uses the path property which does not contain any querystring parameters. 

Fixes #203 