### PR TITLE
Use query string parameter to skip beta redirect

### DIFF
--- a/app/views/_includes/new-site-message.nunjucks
+++ b/app/views/_includes/new-site-message.nunjucks
@@ -6,6 +6,6 @@
     {% else %}
       Go
     {% endif %}
-    <a href="http://www.nhs.uk/{{ choicesOrigin }}" data-analytics="external">back to NHS Choices.</a>
+    <a href="http://www.nhs.uk/{{ choicesOrigin }}?nobeta=true" data-analytics="external">back to NHS Choices.</a>
   </p>
 </div>


### PR DESCRIPTION
This prevents users from ending up in a redirect loop if they choose to
go back to the equivalent Choices page after already having been
redirected.