### PR TITLE
Amend fungal nail wording to be less confusing

### DIFF
--- a/content/conditions/fungal-nail-infection/main-content.md
+++ b/content/conditions/fungal-nail-infection/main-content.md
@@ -63,7 +63,7 @@ and have hot, sweaty feet.
 Treat athlete’s foot as soon as possible to avoid it spreading to the nails.
 !!!
 
-To prevent fungal nail infection you should:
+To prevent fungal nail infection:
 
 * keep your feet clean and dry
 * wear clean socks every day


### PR DESCRIPTION
The original wording around actions to take to prevent fungal nail infection was slightly confusing as it included a combination of "you should" and "don't". 

We've removed "you should" so the actions read better. 