### PR TITLE
Add --debug arg to nodemon to be able to run a debugging session

### DIFF
--- a/gulp/tasks/serve.js
+++ b/gulp/tasks/serve.js
@@ -12,6 +12,7 @@ module.exports = (gulp, done) => {
   nodemon({
     script: 'app.js',
     ext: 'js nunjucks',
+    exec: 'node --debug',
     ignore: [
       './assets',
       './tmp',


### PR DESCRIPTION
Can be used with either [node-inspector](https://github.com/node-inspector/node-inspector) or WebStorm.