### PR TITLE
Break on Sass error

### DIFF
--- a/assets/stylesheets/nhsuk.scss
+++ b/assets/stylesheets/nhsuk.scss
@@ -6,7 +6,6 @@
 
 @import "environment/tools/mixins/colour";
 @import "environment/tools/mixins/conditionals";
-@import "environment/tools/mixins/css3";
 @import "environment/tools/mixins/device-pixels";
 @import "environment/tools/mixins/grid-layout";
 @import "environment/tools/mixins/typography";

--- a/gulp/tasks/build/css.js
+++ b/gulp/tasks/build/css.js
@@ -13,13 +13,18 @@ const SASS_PATHS = [
   `${paths.nodeModules}`,
 ];
 
+function handleError(error) {
+  sass.logError.call(this, error);
+  process.exit(1);
+}
+
 module.exports = (gulp) => {
   return gulp.src(`${paths.sourceStyles}/**/*.scss`)
     .pipe(gulpif(!isProduction, sourcemaps.init()))
     .pipe(sass({
       includePaths: SASS_PATHS,
       outputStyle: isProduction ? 'compressed' : 'expanded',
-    }).on('error', sass.logError))
+    }).on('error', handleError))
     .pipe(autoprefixer({
       browsers: ['> 0%', 'IE 8'],
     }))


### PR DESCRIPTION
Previous [PR](https://github.com/nhsuk/betahealth/pull/226) had an import reference to deleted mixin which was showing Sass error in console but allowed the build to complete. This allowed to deploy site without styles.