### PR TITLE
Markdown custom containers

### DIFF
--- a/app/views/_md-filters/alert.nunjucks
+++ b/app/views/_md-filters/alert.nunjucks
@@ -1,0 +1,3 @@
+<section class="callout callout--alert">
+  <!--content-->
+</section>

--- a/app/views/_md-filters/attention.nunjucks
+++ b/app/views/_md-filters/attention.nunjucks
@@ -1,0 +1,3 @@
+<section class="callout callout--attention">
+  <!--content-->
+</section>

--- a/app/views/_md-filters/info.nunjucks
+++ b/app/views/_md-filters/info.nunjucks
@@ -1,0 +1,3 @@
+<section class="callout callout--info callout--compact">
+  <!--content-->
+</section>

--- a/app/views/_md-filters/info_compact.nunjucks
+++ b/app/views/_md-filters/info_compact.nunjucks
@@ -1,0 +1,3 @@
+<section class="callout callout--info callout--compact">
+  <!--content-->
+</section>

--- a/app/views/_md-filters/inline_reveal.nunjucks
+++ b/app/views/_md-filters/inline_reveal.nunjucks
@@ -1,0 +1,10 @@
+<details class="details--inline">
+  <summary data-analytics="summary">
+    <span class="details__summary">
+      {{ title.replace('[', '<span class="details__cta">').replace(']', '</span>') | safe }}
+    </span>
+  </summary>
+  <div>
+    <!--content-->
+  </div>
+</details>

--- a/app/views/_md-filters/reveal.nunjucks
+++ b/app/views/_md-filters/reveal.nunjucks
@@ -1,0 +1,8 @@
+<details>
+  <summary data-analytics="summary">
+    <span class="details__summary">{{ title }}</span>
+  </summary>
+  <div>
+    <!--content-->
+  </div>
+</details>

--- a/app/views/_md-filters/severe.nunjucks
+++ b/app/views/_md-filters/severe.nunjucks
@@ -1,0 +1,3 @@
+<section class="callout callout--severe">
+  <!--content-->
+</section>

--- a/app/views/_md-filters/warning.nunjucks
+++ b/app/views/_md-filters/warning.nunjucks
@@ -1,0 +1,3 @@
+<section class="callout callout--warning">
+  <!--content-->
+</section>

--- a/config/express.js
+++ b/config/express.js
@@ -22,6 +22,7 @@ const csrf = require('csurf');
 const changeCase = require('change-case');
 const slashify = require('slashify');
 const logger = require('../lib/logger');
+const customMdFilter = require('../lib/custom-md-filter');
 const checkSecure = require('../app/middleware/check-secure');
 const locals = require('../app/middleware/locals');
 const assetPath = require('../app/middleware/asset-path');
@@ -32,95 +33,13 @@ const router = require('./routes');
 
 md.use(markdownItAbbr);
 md.use(markdownItAttrs);
-md.use(markdownItContainer, 'info', {
-  marker: '!',
-  render: (tokens, idx) => {
-    if (tokens[idx].nesting === 1) {
-      return '<section class="callout callout--info">\n';
-    }
-    return '</section>\n';
-  },
-});
-md.use(markdownItContainer, 'info_compact', {
-  marker: '!',
-  render: (tokens, idx) => {
-    if (tokens[idx].nesting === 1) {
-      return '<section class="callout callout--info callout--compact">\n';
-    }
-    return '</section>\n';
-  },
-});
-md.use(markdownItContainer, 'attention', {
-  marker: '!',
-  render: (tokens, idx) => {
-    if (tokens[idx].nesting === 1) {
-      return '<section class="callout callout--attention">\n';
-    }
-    return '</section>\n';
-  },
-});
-md.use(markdownItContainer, 'warning', {
-  marker: '!',
-  render: (tokens, idx) => {
-    if (tokens[idx].nesting === 1) {
-      return '<section class="callout callout--warning">\n';
-    }
-    return '</section>\n';
-  },
-});
-md.use(markdownItContainer, 'alert', {
-  marker: '!',
-  render: (tokens, idx) => {
-    if (tokens[idx].nesting === 1) {
-      return '<section class="callout callout--alert">\n';
-    }
-    return '</section>\n';
-  },
-});
-md.use(markdownItContainer, 'severe', {
-  marker: '!',
-  render: (tokens, idx) => {
-    if (tokens[idx].nesting === 1) {
-      return '<section class="callout callout--severe">\n';
-    }
-    return '</section>\n';
-  },
-});
-md.use(markdownItContainer, 'reveal', {
-  marker: ':',
-  validate: (params) => {
-    return params.trim().match(/^reveal\s+(.*)$/);
-  },
-  render: (tokens, idx) => {
-    const m = tokens[idx].info.trim().match(/^reveal\s+(.*)$/);
 
-    if (tokens[idx].nesting === 1) {
-      return `<details>\n<summary data-analytics="summary"><span class="details__summary">${md.utils.escapeHtml(m[1])}</span></summary>\n<div>\n`;
-    }
-    return '</div>\n</details>\n';
-  },
+['info', 'info_compact', 'attention', 'warning', 'alert', 'severe'].forEach((filterName) => {
+  md.use.call(md, markdownItContainer, filterName, customMdFilter('!', filterName));
 });
-md.use(markdownItContainer, 'inline_reveal', {
-  marker: ':',
-  validate: (params) => {
-    return params.trim().match(/^inline_reveal\s+(.*)$/);
-  },
-  render: (tokens, idx) => {
-    const m = tokens[idx].info.trim().match(/^inline_reveal\s+(.*)$/);
 
-    if (tokens[idx].nesting === 1) {
-      const summary = md.utils.escapeHtml(m[1]);
-      const cta = summary.slice(summary.indexOf('['), summary.indexOf(']') + 1);
-      const ctaHtml = cta.replace('[', '<span class="details__cta">').replace(']', '</span>');
-
-      return `<details class="details--inline">
-        <summary data-analytics="summary">
-          <span class="details__summary">${summary.replace(cta, ctaHtml)}</span>
-        </summary>
-        <div>`;
-    }
-    return '</div>\n</details>\n';
-  },
+['reveal', 'inline_reveal'].forEach((filterName) => {
+  md.use.call(md, markdownItContainer, filterName, customMdFilter(':', filterName, true));
 });
 
 module.exports = (app, config) => {

--- a/gulp/tasks/dev/watch.js
+++ b/gulp/tasks/dev/watch.js
@@ -13,6 +13,7 @@ module.exports = {
     gulp.watch([
       `${paths.sourceApp}/**/*.js`,
       `${paths.sourceViews}/**/*.nunjucks`,
+      `${paths.projectDir}/**/*.md`,
     ]).on('change', browserSync.reload);
   },
 };

--- a/lib/custom-md-filter.js
+++ b/lib/custom-md-filter.js
@@ -1,0 +1,75 @@
+const fs = require('fs');
+const isString = require('lodash/isString');
+const nunjucks = require('nunjucks');
+const config = require('../config/config');
+
+const VIEWS_PATH = `${config.root}/app/views/_md-filters`;
+
+// Anything following filter name (which has to be without spaces) is treated as parameters:
+// key/values separated by comma.
+// e.g. ::: reveal title: Expand menu, type: inline
+// When no key/value pairs are provided it defaults to value under key `title`
+function paramsToObj(params) {
+  const obj = {};
+  let isTitle = true;
+
+  if (params) {
+    params.split(',').forEach((param) => {
+      const keyVals = param.split(':');
+      if (keyVals.length > 1) {
+        isTitle = false;
+        Object.assign(obj, {
+          [keyVals[0].trim()]: keyVals[1].trim(),
+        });
+      }
+    });
+    if (isTitle) {
+      obj.title = params;
+    }
+  }
+
+  return obj;
+}
+
+function customMdFilter(marker, name, hasParams = false) {
+  const contentPlaceholderPattern = /<!--\s*?content\s*?-->/;
+  const filterNamePattern = new RegExp(`^${name}\\s+(.*)$`);
+  const template = fs.readFileSync(`${VIEWS_PATH}/${name}.nunjucks`, 'utf-8');
+
+  const filter = {
+    marker,
+    render: (tokens, idx) => {
+      const node = tokens[idx];
+      const isOpening = node.nesting === 1;
+      const contentMatch = template.match(contentPlaceholderPattern);
+
+      if (!contentMatch) {
+        throw Error('Filter template requires <!--content--> placeholder to inject inner content');
+      }
+
+      const paramsMatch = node.info && node.info.trim().match(filterNamePattern);
+      const templateHead = template.slice(0, contentMatch.index);
+      const templateTail = template.slice(contentMatch.index + contentMatch[0].length);
+      const params = Array.isArray(paramsMatch) ? paramsMatch[1] : '';
+      const context = paramsToObj(params);
+
+      if (isOpening) {
+        return nunjucks.renderString(templateHead, context);
+      }
+      return nunjucks.renderString(templateTail, context);
+    },
+  };
+
+  if (hasParams) {
+    filter.validate = (params) => {
+      if (!isString(params)) {
+        throw Error('params must be provided if `hasParams` is enabled');
+      }
+      return params.trim().match(filterNamePattern);
+    };
+  }
+
+  return filter;
+}
+
+module.exports = customMdFilter;

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "mock-fs": "~3.12.1",
     "progress": "~1.1.8",
     "proxyquire": "~1.7.10",
+    "rewire": "^2.5.2",
     "selenium-standalone": "~5.8.0",
     "sinon": "~1.17.6",
     "sinon-chai": "~2.8.0",

--- a/test/unit/lib/custom-md-filter.js
+++ b/test/unit/lib/custom-md-filter.js
@@ -1,0 +1,122 @@
+const path = require('path');
+const mock = require('mock-fs');
+const rewire = require('rewire');
+
+const customMdFilter = rewire('../../../lib/custom-md-filter');
+
+const markdownAst = [
+  {
+    type: 'container_warning_open',
+    nesting: 1,
+  },
+  {
+    type: 'paragraph_open',
+  },
+  {
+    type: 'inline',
+    content: 'inner text',
+  },
+  {
+    type: 'paragraph_close',
+  },
+  {
+    type: 'container_warning_close',
+    nesting: -1,
+  },
+];
+
+describe('Markdown custom filters', () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  describe('#customMdFilter', () => {
+    beforeEach(() => {
+      mock({
+        [path.resolve(__dirname, '../../../app/views/_md-filters')]: {
+          'blob.nunjucks': '<div><!--content--></div>',
+          'warning.nunjucks': '<div>{% if title %}<h1>{{title}}</h1>{% endif %}<!--content--></div>',
+          'empty.nunjucks': '',
+        },
+      });
+    });
+
+    it('should set marker on filter object', () => {
+      const filter = customMdFilter('!', 'blob');
+      filter.marker.should.equal('!');
+    });
+
+    it('should throw an error when template is missing content placeholder', () => {
+      const filter = customMdFilter('!', 'empty');
+      (() => {
+        filter.render(markdownAst, 0);
+      }).should.throw(/requires <!--content-->/);
+    });
+
+    it('should render opening and closing HTML of filter template', () => {
+      const filter = customMdFilter('!', 'blob');
+      filter.render(markdownAst, 0).should.equal('<div>');
+      filter.render(markdownAst, 4).should.equal('</div>');
+    });
+
+    it('should render compile HTML in Nunjucks', () => {
+      const filter = customMdFilter('!', 'warning');
+
+      const markdownAstwithAttrs = markdownAst.slice(0);
+      markdownAstwithAttrs[0].info = ' warning title: Attention'; // Add filter params
+
+      filter.render(markdownAst, 0).should.equal('<div><h1>Attention</h1>');
+      filter.render(markdownAst, 4).should.equal('</div>');
+    });
+  });
+
+  describe('#validate', () => {
+    it('should throw when hasParams is set to true and no params are given', () => {
+      const filter = customMdFilter('!', 'warning', true);
+
+      (() => {
+        filter.validate();
+      }).should.throw('params must be provided if `hasParams` is enabled');
+    });
+
+    it('should return array with found instances of params specified', () => {
+      const filter = customMdFilter('!', 'warning', true);
+
+      filter.validate('warning Attention').should.be.an('array');
+      filter.validate('warning Attention')[1].should.equal('Attention');
+      filter.validate('warning title: Attention, subtitle: Less important').should.be.an('array');
+      filter.validate('warning title: Attention, subtitle: Less important')[1].should.equal('title: Attention, subtitle: Less important');
+    });
+  });
+
+  describe('#paramsToObj', () => {
+    const paramsToObj = customMdFilter.__get__('paramsToObj');
+
+    it('should return an object', () => {
+      paramsToObj().should.be.an('object');
+    });
+
+    describe('single param', () => {
+      it('should return an object with title prop when single param is given', () => {
+        paramsToObj('Simple title').should.deep.equal({
+          title: 'Simple title',
+        });
+      });
+
+      it('should return an object with title prop when comma-separated and without key/value separator (colon)', () => {
+        paramsToObj('Simple title, comma-separated').should.deep.equal({
+          title: 'Simple title, comma-separated',
+        });
+      });
+    });
+
+    describe('multiple params', () => {
+      it('should return an object representing string of parameters with key/value separator (colon)', () => {
+        paramsToObj('title: Simple title, subtitle: Less important').should.deep.equal({
+          title: 'Simple title',
+          subtitle: 'Less important',
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
We use [MarkdownIt Containers](https://github.com/markdown-it/markdown-it-container) extension  to create custom filters in MD documents which are expanded into custom fragments with custom HTML wrappers.

This PR moves HTML out of JS and makes use of Nunjucks. It also allows to pass key/value parameters to template to set additional context.

[Trello card](https://trello.com/c/7FsMi4Z5/217-improve-code-for-custom-markdown-filters)