### PR TITLE
Separate content store and image store config

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,36 +42,37 @@ This application is a Node based application that runs on [beta.nhs.uk](http://b
 Environment variables are used to set application level settings for each
 environment.
 
-| Variable                           | Description                                                               | Default                  |
-|:-----------------------------------|:--------------------------------------------------------------------------|:-------------------------|
-| `NODE_ENV`                         | node environment                                                          | development              |
-| `PORT`                             | server port                                                               | 3000                     |
-| `GOOGLE_ANALYTICS_TRACKING_ID`     | Google Analytics property id                                              |                          |
-| `WEBTRENDS_TRACKING_ID`            | [Webtrends](https://www.webtrends.com/) tracking id                       |                          |
-| `HOTJAR_TRACKING_ID`               | [Hotjar](https://www.hotjar.com/) tracking id                             |                          |
-| `FONT_CDN`                         | Base url where the font is served                                         | /                        |
-| `STATIC_CDN`                       | Base url where all other assets are served                                |                          |
-| `LOG_LEVEL`                        | Level of logging to user                                                  | warn                     |
-| `WDIO_BASEURL`                     | base URL for webdriver to use for acceptance tests                        | http://localhost:${PORT} |
-| `WDIO_SCREENSHOTPATH`              | path where webdriver screenshots are saved                                |                          |
-| `WDIO_REPORTPATH`                  | path where webdriverio test runner reports are saved                      |                          |
-| `BROWSERSTACK_USERNAME`            | Browserstack username                                                     |                          |
-| `BROWSERSTACK_ACCESS_KEY`          | Browserstack access key                                                   |                          |
-| `TRAVIS_BUILD_NUMBER`              | The number of the current Travis build                                    |                          |
-| `TRAVIS_JOB_NUMBER`                | The number of the current Travis job                                      |                          |
-| `DISABLE_FEEDBACK`                 | Whether to disable feedback. On by default. Set this to `true` to disable |                          |
-| `FEEDBACK_API_BASEURL`             | Base feedback endpoint                                                    |                          |
-| `FEEDBACK_API_KEY`                 | Key for feedback API if needed                                            |                          |
-| `FEEDBACK_TIMEOUT`                 | Timeout before the request to the API fails                               | 5000                     |
-| `APPINSIGHTS_INSTRUMENTATIONKEY`   | Application insights instrumentation key                                  |                          |
-| `CONNECTINGTOSERVICES_BASEURL`     | Base URL for connecting to services application                           | /                        |
-| `CONTENTSTORE_TYPE`                | Operational mode for content store (`rest` or `file`)                     | file                     |
-| `CONTENTSTORE_BASEURL`             | Base URL for the content store API                                        |                          |
-| `CONTENTSTORE_AUTH_TOKEN`          | OAuth2 bearer token for authenticating with the API                       |                          |
-| `CONTENTSTORE_TIMEOUT`             | Timeout before the request to the API fails                               | 5000                     |
-| `CONTENTSTORE_IMAGE_SIGNATURE_KEY` | Key used to generate the signature for image paths from the content store |                          |
-| `CONTENTSTORE_IMAGE_PROXY_PATH`    | The local path to use for the image proxy                                 | /content-images          |
-| `PREVIEW_SIGNATURE_KEY`            | Key used to generate the signature for preview  pages in content store    |                          |
+| Variable                           | Description                                                                         | Default                  |
+|:-----------------------------------|:------------------------------------------------------------------------------------|:-------------------------|
+| `NODE_ENV`                         | node environment                                                                    | development              |
+| `PORT`                             | server port                                                                         | 3000                     |
+| `GOOGLE_ANALYTICS_TRACKING_ID`     | Google Analytics property id                                                        |                          |
+| `WEBTRENDS_TRACKING_ID`            | [Webtrends](https://www.webtrends.com/) tracking id                                 |                          |
+| `HOTJAR_TRACKING_ID`               | [Hotjar](https://www.hotjar.com/) tracking id                                       |                          |
+| `FONT_CDN`                         | Base url where the font is served                                                   | /                        |
+| `STATIC_CDN`                       | Base url where all other assets are served                                          |                          |
+| `LOG_LEVEL`                        | Level of logging to user                                                            | warn                     |
+| `WDIO_BASEURL`                     | base URL for webdriver to use for acceptance tests                                  | http://localhost:${PORT} |
+| `WDIO_SCREENSHOTPATH`              | path where webdriver screenshots are saved                                          |                          |
+| `WDIO_REPORTPATH`                  | path where webdriverio test runner reports are saved                                |                          |
+| `BROWSERSTACK_USERNAME`            | Browserstack username                                                               |                          |
+| `BROWSERSTACK_ACCESS_KEY`          | Browserstack access key                                                             |                          |
+| `TRAVIS_BUILD_NUMBER`              | The number of the current Travis build                                              |                          |
+| `TRAVIS_JOB_NUMBER`                | The number of the current Travis job                                                |                          |
+| `DISABLE_FEEDBACK`                 | Whether to disable feedback. On by default. Set this to `true` to disable           |                          |
+| `FEEDBACK_API_BASEURL`             | Base feedback endpoint                                                              |                          |
+| `FEEDBACK_API_KEY`                 | Key for feedback API if needed                                                      |                          |
+| `FEEDBACK_TIMEOUT`                 | Timeout before the request to the API fails                                         | 5000                     |
+| `APPINSIGHTS_INSTRUMENTATIONKEY`   | Application insights instrumentation key                                            |                          |
+| `CONNECTINGTOSERVICES_BASEURL`     | Base URL for connecting to services application                                     | /                        |
+| `CONTENTSTORE_TYPE`                | Operational mode for content store (`rest` or `file`)                               | file                     |
+| `CONTENTSTORE_API_BASEURL`         | Base URL for the content store API, eg `http://hostname.com/api`. No trailing slash |                          |
+| `CONTENTSTORE_AUTH_TOKEN`          | OAuth2 bearer token for authenticating with the API                                 |                          |
+| `CONTENTSTORE_TIMEOUT`             | Timeout before the request to the API fails                                         | 5000                     |
+| `CONTENTSTORE_IMAGE_BASEURL`       | Base url for the image endpoint, eg `http://hostname.com/images`. No trailing slash |                          |
+| `CONTENTSTORE_IMAGE_SIGNATURE_KEY` | Key used to generate the signature for image paths from the content store           |                          |
+| `CONTENTSTORE_IMAGE_PROXY_PATH`    | The local path to use for the image proxy                                           | /content-images          |
+| `PREVIEW_SIGNATURE_KEY`            | Key used to generate the signature for preview  pages in content store              |                          |
 
 timeout: process.env.CONTENTSTORE_TIMEOUT || 5000,
 baseUrl: process.env.CONTENTSTORE_BASEURL,

--- a/config/config.js
+++ b/config/config.js
@@ -41,8 +41,9 @@ module.exports = {
   contentStore: {
     type: process.env.CONTENTSTORE_TYPE || 'file',
     timeout: process.env.CONTENTSTORE_TIMEOUT || 5000,
-    baseUrl: process.env.CONTENTSTORE_BASEURL,
+    apiBaseUrl: process.env.CONTENTSTORE_API_BASEURL,
     authToken: process.env.CONTENTSTORE_AUTH_TOKEN,
+    imageBaseUrl: process.env.CONTENTSTORE_IMAGE_BASEURL,
     imageSignatureKey: process.env.CONTENTSTORE_IMAGE_SIGNATURE_KEY,
     imageProxyPath: process.env.CONTENTSTORE_IMAGE_PROXY_PATH || '/content-images',
   },

--- a/config/routes/image-proxy-router.js
+++ b/config/routes/image-proxy-router.js
@@ -6,9 +6,9 @@ const config = require('../config');
 
 
 router.use(config.contentStore.imageProxyPath, proxy({
-  target: `${config.contentStore.baseUrl}`,
+  target: `${config.contentStore.imageBaseUrl}`,
   pathRewrite: {
-    '^/content-images': '/images',
+    '^/content-images': '',
   },
   changeOrigin: true,
 }));

--- a/lib/content-store/rest-handler.js
+++ b/lib/content-store/rest-handler.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 
 const config = require('../../config/config');
 
-const BASE_URL = config.contentStore.baseUrl;
+const BASE_URL = config.contentStore.apiBaseUrl;
 const AUTH_TOKEN = config.contentStore.authToken;
 const TIMEOUT = config.contentStore.timeout;
 const IMAGE_PROXY_PATH = config.contentStore.imageProxyPath;
@@ -76,7 +76,7 @@ function fetchData(endpoint, pathname) {
       method: 'GET',
       json: true,
       timeout: TIMEOUT,
-      uri: `${BASE_URL}/api/${endpoint}/${pathname}`,
+      uri: `${BASE_URL}/${endpoint}/${pathname}`,
       headers: {
         Authorization: `Bearer ${AUTH_TOKEN}`,
       },

--- a/test/unit/lib/content-store/rest-handler.test.js
+++ b/test/unit/lib/content-store/rest-handler.test.js
@@ -3,9 +3,10 @@ const rewire = require('rewire');
 const slug = 'path/to/page';
 const config = {
   contentStore: {
-    baseUrl: 'http://api-baseurl.com',
+    apiBaseUrl: 'http://api-baseurl.com/api',
     authToken: 'APIKEY123456789',
     timeout: 5000,
+    imageBaseUrl: 'http://api-baseurl.com/images',
     imageSignatureKey: 'signaturekey',
     imageProxyPath: '/image-path',
   },
@@ -89,7 +90,7 @@ describe('REST API Handler library', () => {
             method: 'GET',
             json: true,
             timeout: config.contentStore.timeout,
-            uri: `${config.contentStore.baseUrl}/api/pages/with-path/${slug}/`,
+            uri: `${config.contentStore.apiBaseUrl}/pages/with-path/${slug}/`,
             headers: {
               Authorization: `Bearer ${config.contentStore.authToken}`,
             },


### PR DESCRIPTION
There may be a case we want to use separate services for the two so
this allows the image base url to be updated without affecting the
content API