### PR TITLE
Ensure Gemfile.lock contains correct version of scss_lint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,15 +3,15 @@ GEM
   specs:
     rake (11.3.0)
     sass (3.4.22)
-    scss_lint (0.50.2)
+    scss_lint (0.48.0)
       rake (>= 0.9, < 12)
-      sass (~> 3.4.20)
+      sass (~> 3.4.15)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  scss_lint (= 0.50.2)
+  scss_lint (= 0.48.0)
 
 BUNDLED WITH
    1.11.2


### PR DESCRIPTION
The Gemfile.lock uses a newer version of scss_lint that we want to
use right now.