### PR TITLE
Add fallback handler for both REST and File System

### DIFF
--- a/lib/content-store/fallback-handler.js
+++ b/lib/content-store/fallback-handler.js
@@ -1,0 +1,41 @@
+const detectSeries = require('async').detectSeries;
+
+const logger = require('../logger');
+const restHandler = require('./rest-handler');
+const fileHandler = require('./file-handler');
+
+const handlers = [
+  restHandler,
+  fileHandler,
+];
+
+
+const FallbackHandler = {
+  name: 'Fallback - API then File System',
+  get(pathname) {
+    let record;
+
+    return new Promise((resolve, reject) => {
+      detectSeries(handlers, (handler, callback) => {
+        handler.get(pathname)
+          .then((result) => {
+            record = result;
+            logger.verbose(`Content handler: ${handler.name}`);
+            callback(null, true);
+          })
+          .catch(() => {
+            callback(null, false);
+          });
+      }, (err, result) => {
+        if (!result) {
+          return reject(new Error('Record could not be found'));
+        }
+
+        return resolve(record);
+      });
+    });
+  },
+  preview: restHandler.preview,
+};
+
+module.exports = FallbackHandler;

--- a/lib/content-store/index.js
+++ b/lib/content-store/index.js
@@ -1,25 +1,38 @@
 const config = require('../../config/config');
 const logger = require('../logger');
 const restHandler = require('./rest-handler');
+const fallbackHandler = require('./fallback-handler');
 const fileHandler = require('./file-handler');
 
 const HANDLER_TYPE = config.contentStore.type;
 
 
 function getHandler(type) {
-  logger.verbose(`Content handler: ${type}`);
-
   if (!type) {
     throw Error('Content handler type is missing. Check `contentStoreType` in config');
   }
 
+  let handler;
+
   switch (type) {
     case 'rest':
-      return restHandler;
+      handler = restHandler;
+      break;
+    case 'fallback':
+      handler = fallbackHandler;
+      break;
     case 'file':
+      handler = fileHandler;
+      break;
     default:
-      return fileHandler;
+      throw Error(`Could not find a handler matching ${type}`);
   }
+
+  if (handler) {
+    logger.verbose(`Content handler: ${handler.name}`);
+  }
+
+  return handler;
 }
 
 const ContentStore = {

--- a/test/unit/lib/content-store/fallback-handler.test.js
+++ b/test/unit/lib/content-store/fallback-handler.test.js
@@ -1,0 +1,97 @@
+describe('REST API Handler library', () => {
+  afterEach(() => {
+    this.sandbox.restore();
+  });
+
+  describe('#get', () => {
+    beforeEach(() => {
+      this.sandbox = sinon.sandbox.create();
+      this.verbose = this.sandbox.stub();
+      this.restGet = this.sandbox.stub().returnsPromise();
+      this.restPreview = this.sandbox.stub().returnsPromise();
+      this.fileGet = this.sandbox.stub().returnsPromise();
+
+      this.fallbackHandler = proxyquire(`${rootFolder}/lib/content-store/fallback-handler`, {
+        './rest-handler': {
+          get: this.restGet,
+          preview: this.restPreview,
+        },
+        './file-handler': {
+          get: this.fileGet,
+        },
+        '../logger': {
+          verbose: this.verbose,
+        },
+      });
+    });
+
+    describe('REST handler resolves a record', () => {
+      const record = {
+        foo: 'bar',
+      };
+
+      beforeEach(() => {
+        this.restGet.resolves(record);
+      });
+
+      it('return the REST record', () => {
+        const fallbackGet = this.fallbackHandler.get('slug');
+
+        this.restGet.should.have.been.called;
+        this.fileGet.should.not.have.been.called;
+        return fallbackGet.should.become(record);
+      });
+    });
+
+    describe('REST handler rejects, File handler resolves', () => {
+      const record = {
+        foo: 'bar',
+      };
+
+      beforeEach(() => {
+        this.restGet.rejects();
+        this.fileGet.resolves(record);
+      });
+
+      it('return the file record', () => {
+        const fallbackGet = this.fallbackHandler.get('slug');
+
+        this.restGet.should.have.been.called;
+        this.fileGet.should.have.been.called;
+        return fallbackGet.should.become(record);
+      });
+    });
+
+    describe('Both handlers reject', () => {
+      beforeEach(() => {
+        this.restGet.rejects();
+        this.fileGet.rejects();
+      });
+
+      it('return an error', () => {
+        const fallbackGet = this.fallbackHandler.get('slug');
+
+        this.restGet.should.have.been.called;
+        this.fileGet.should.have.been.called;
+        return fallbackGet.should.be.rejectedWith('Record could not be found');
+      });
+    });
+  });
+
+  describe('#preview', () => {
+    const record = {
+      foo: 'bar',
+    };
+
+    beforeEach(() => {
+      this.restPreview.resolves(record);
+    });
+
+    it('should call the rest preview method', () => {
+      const fallbackPreview = this.fallbackHandler.preview('slug');
+
+      this.restPreview.should.have.been.called;
+      return fallbackPreview.should.become(record);
+    });
+  });
+});


### PR DESCRIPTION
This handler will use the REST handler first to find a record
but then fallback to the File System if it cannot get a record.

If neither returns a record it rejects the promise.