### PR TITLE
Add split panel component macro support

### DIFF
--- a/app/views/_macros/components.nunjucks
+++ b/app/views/_macros/components.nunjucks
@@ -240,3 +240,15 @@
     {% endif %}
   </article>
 {% endmacro %}
+
+{% macro split_panel(content) %}
+  <article class="panel">
+    <div class="panel__content panel__content--half">
+      {{ markdown(content[0]) }}
+    </div>
+
+    <div class="panel__content panel__content--half">
+      {{ markdown(content[1]) }}
+    </div>
+  </article>
+{% endmacro %}


### PR DESCRIPTION
This allows the split panel, which stacks on small screen widths
and display inline on wider widths, to be support via the API.