### PR TITLE
Remove reading width restriction from panel component

### DIFF
--- a/app/views/_macros/components.nunjucks
+++ b/app/views/_macros/components.nunjucks
@@ -227,8 +227,8 @@
   </nav>
 {% endmacro %}
 
-{% macro panel(content) %}
-  <article class="panel">
+{% macro panel(content, reading_width=true) %}
+  <article class="panel{{ ' reading-width' if reading_width }}">
     <div class="panel__content">
       {{ markdown(content.main) }}
     </div>
@@ -242,7 +242,7 @@
 {% endmacro %}
 
 {% macro split_panel(content) %}
-  <article class="panel">
+  <div class="panel">
     <div class="panel__content panel__content--half">
       {{ markdown(content[0]) }}
     </div>
@@ -250,5 +250,5 @@
     <div class="panel__content panel__content--half">
       {{ markdown(content[1]) }}
     </div>
-  </article>
+  </div>
 {% endmacro %}

--- a/app/views/elements.nunjucks
+++ b/app/views/elements.nunjucks
@@ -208,47 +208,49 @@
       <div class="callout callout--severe">
         <p>A severe callout</p>
       </div>
+    </div>
 
-      <h2>Panels</h2>
+    <h2>Panels</h2>
 
-      <article class="panel">
-        <div class="panel__content">
-          <h2>Panel heading</h2>
+    <article class="panel">
+      <div class="panel__content">
+        <h2>Panel heading</h2>
 
-          <ul class="list--chevron">
-            <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit</li>
-            <li>Officiis excepturi atque et, a</li>
-            <li>Totam, dolorum culpa eum tenetur temporibus in assumenda vel mollitia alias</li>
-          </ul>
-        </div>
+        <ul class="list--chevron">
+          <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit</li>
+          <li>Officiis excepturi atque et, a</li>
+          <li>Totam, dolorum culpa eum tenetur temporibus in assumenda vel mollitia alias</li>
+        </ul>
+      </div>
 
-        <footer class="panel__footer">
-          <p><strong>Panel footer, usually an action to take.</strong></p>
-        </footer>
-      </article>
+      <footer class="panel__footer">
+        <p><strong>Panel footer, usually an action to take.</strong></p>
+      </footer>
+    </article>
 
-      <section class="panel">
-        <div class="panel__content panel__content--half">
-          <h3>Do</h3>
+    <section class="panel">
+      <div class="panel__content panel__content--half">
+        <h3>Do</h3>
 
-          <ul class="list--check">
-            <li>this thing</li>
-            <li>another thing</li>
-            <li>and also this</li>
-          </ul>
-        </div>
+        <ul class="list--check">
+          <li>this thing</li>
+          <li>another thing</li>
+          <li>and also this</li>
+        </ul>
+      </div>
 
-        <div class="panel__content panel__content--half">
-          <h3>Don't</h3>
+      <div class="panel__content panel__content--half">
+        <h3>Don't</h3>
 
-          <ul class="list--cross">
-            <li>this thing</li>
-            <li>vivamus magna</li>
-            <li>and also this</li>
-          </ul>
-        </div>
-      </section>
+        <ul class="list--cross">
+          <li>this thing</li>
+          <li>vivamus magna</li>
+          <li>and also this</li>
+        </ul>
+      </div>
+    </section>
 
+    <div class="reading-width">
       <h2>Hidden text (progressive disclosure)</h2>
 
       <details>

--- a/assets/stylesheets/components/_panel.scss
+++ b/assets/stylesheets/components/_panel.scss
@@ -1,6 +1,5 @@
 .panel {
   @extend %clearfix;
-  @extend %measure;
   background-color: $grey-4;
   display: table;
   width: 100%;


### PR DESCRIPTION
Panels should be allowed to use the full space if required.

Where we're currently using the default panel styling we
will continue to restrict its width. But this can be done
using the reading-width class.