### PR TITLE
Ensure all in-page anchor links have tracking attribute

### DIFF
--- a/app/views/_includes/local-header.nunjucks
+++ b/app/views/_includes/local-header.nunjucks
@@ -16,7 +16,7 @@
 
       {% for component in content.header %}
         {% if component.type.toLowerCase().indexOf('nav') != -1 %}
-          {{ components[component.type | snakecase](main) }}
+          {{ components[component.type | snakecase](content.main) }}
         {% else %}
           {{ components[component.type | snakecase](component.value) }}
         {% endif %}

--- a/content/conditions/constipation/local-header.md
+++ b/content/conditions/constipation/local-header.md
@@ -1,9 +1,9 @@
 Constipation is common and it affects people of all ages. You can usually treat it at
 home with simple changes to your diet and lifestyle.
 
-- [Check if it is constipation](#check-if-it-is-constipation)
-- [Constipation in adults](#how-you-can-treat-constipation-yourself)
-- [Constipation in babies and toddlers](#babies-and-toddlers-what-causes-constipation)
-- [How your pharmacist can help](#your-pharmacist-can-help-with-constipation)
-- [Complications of long-term constipation](#complications-of-long-term-constipation)
+- [Check if it is constipation](#check-if-it-is-constipation){data-analytics=anchor}
+- [Constipation in adults](#how-you-can-treat-constipation-yourself){data-analytics=anchor}
+- [Constipation in babies and toddlers](#babies-and-toddlers-what-causes-constipation){data-analytics=anchor}
+- [How your pharmacist can help](#your-pharmacist-can-help-with-constipation){data-analytics=anchor}
+- [Complications of long-term constipation](#complications-of-long-term-constipation){data-analytics=anchor}
 {.link-list}

--- a/content/conditions/dehydration/local-header.md
+++ b/content/conditions/dehydration/local-header.md
@@ -1,6 +1,6 @@
 Dehydration means your body loses more fluids than you take in. This can affect your body
 but in most cases it’s nothing serious.
 
-- [Adults and children with dehydration](#check-if-youre-dehydrated)
-- [Babies with dehydration](#babies-with-dehydration)
+- [Adults and children with dehydration](#check-if-youre-dehydrated){data-analytics=anchor}
+- [Babies with dehydration](#babies-with-dehydration){data-analytics=anchor}
 {.link-list}

--- a/content/conditions/diarrhoea/local-header.md
+++ b/content/conditions/diarrhoea/local-header.md
@@ -1,8 +1,8 @@
 Diarrhoea usually goes away on it’s own within a few days. Make sure you or your child drink plenty of fluids.
 
-- [Adults with diarrhoea](#how-you-can-treat-diarrhoea-yourself)
-- [Babies and toddlers with diarrhoea](#babies-and-toddlers-treating-diarrhoea)
-- [How long diarrhoea lasts](#how-long-diarrhoea-lasts)
-- [What causes diarrhoea](#what-causes-diarrhoea)
-- [Preventing diarrhoea](#you-cant-always-prevent-diarrhoea)
+- [Adults with diarrhoea](#how-you-can-treat-diarrhoea-yourself){data-analytics=anchor}
+- [Babies and toddlers with diarrhoea](#babies-and-toddlers-treating-diarrhoea){data-analytics=anchor}
+- [How long diarrhoea lasts](#how-long-diarrhoea-lasts){data-analytics=anchor}
+- [What causes diarrhoea](#what-causes-diarrhoea){data-analytics=anchor}
+- [Preventing diarrhoea](#you-cant-always-prevent-diarrhoea){data-analytics=anchor}
 {.link-list}


### PR DESCRIPTION
We currently use a custom data attribute to track in-page anchor
links.

This was being added when using the section_nav component but gets
missed when manually adding anchor navigation to the local header.

This temporarily adds the correct attribute to the existing navigation
items but will need a better long term fix. This fix may well be applied
at the publisher/content store end.