### PR TITLE
Add node-sass-import-once as Sass importer

### DIFF
--- a/gulp/tasks/shared/css.js
+++ b/gulp/tasks/shared/css.js
@@ -1,4 +1,5 @@
 const sass = require('gulp-sass');
+const importOnce = require('node-sass-import-once');
 const gulpif = require('gulp-if');
 const autoprefixer = require('gulp-autoprefixer');
 const preprocess = require('gulp-preprocess');
@@ -24,6 +25,11 @@ module.exports = (gulp) => {
     .pipe(sass({
       includePaths: SASS_PATHS,
       outputStyle: isProduction ? 'compressed' : 'expanded',
+      importer: importOnce,
+      importOnce: {
+        index: true,
+        css: true
+      }
     }).on('error', handleError))
     .pipe(autoprefixer({
       browsers: ['> 0%', 'IE 8'],

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "method-override": "~2.3.7",
     "moment": "~2.17.1",
     "moment-timezone": "~0.5.11",
+    "node-sass-import-once": "~1.2.0",
     "normalize.css": "~5.0.0",
     "nunjucks": "~3.0.0",
     "nunjucks-markdown": "~2.0.1",


### PR DESCRIPTION
`node-sass-import-once` module allows to:
- remove import duplicates defined in multiple places
- import directory indexes via `_index.scss` (e.g. `@import "units"` will import `units/_index.scss`)