### PR TITLE
Add basic robots.txt file

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /


### PR DESCRIPTION
This change adds a basic [robots.txt](http://www.robotstxt.org/) file. It will prevent 404 errors showing in logs when this file is hit.

It also allows a base file to declare any future definitions for beta.nhs.uk.