### PR TITLE
Move link title from logo's anchor to image `alt`

### DIFF
--- a/app/views/_includes/global/header.nunjucks
+++ b/app/views/_includes/global/header.nunjucks
@@ -1,7 +1,7 @@
 <div class="global-header">
   <div class="global-header__inner">
-    <a href="/" class="global-header__link" title="Go to the NHS.UK homepage">
-      <img src="{{ asset_path('assets/images/logotype-nhs-mono.png') }}" alt="">
+    <a href="/" class="global-header__link">
+      <img src="{{ asset_path('assets/images/logotype-nhs-mono.png') }}" alt="Go to the NHS.UK homepage">
     </a>
   </div>
 </div>


### PR DESCRIPTION
[Reasons](https://silktide.com/i-thought-title-text-improved-accessibility-i-was-wrong/).