### PR TITLE
Improve page meta data to help URL unfurling

### DIFF
--- a/app/middleware/locals.js
+++ b/app/middleware/locals.js
@@ -7,6 +7,7 @@ module.exports = (config) => {
     res.locals.CDN_HOST = config.staticCdn;
     res.locals.FONT_CDN_HOST = config.fontCdn;
     res.locals.ORIGINAL_URL = req.originalUrl;
+    res.locals.CANONICAL_URL = `${(req.isHttps ? 'https' : req.protocol)}://${req.get('host')}${req.originalUrl}`;
     /* eslint-enable no-param-reassign */
     next();
   };

--- a/app/views/_includes/global/head.nunjucks
+++ b/app/views/_includes/global/head.nunjucks
@@ -2,35 +2,53 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta http-equiv="x-ua-compatible" content="ie=edge">
 
-{% if CDN_HOST != '/' %}
+{% if CDN_HOST -%}
   <link href="{{ CDN_HOST }}" rel="dns-prefetch">
-{% endif %}
-{% if FONT_CDN_HOST != '/' %}
+{% endif -%}
+
+{% if FONT_CDN_HOST != '/' -%}
   <link href="{{ FONT_CDN_HOST }}" rel="dns-prefetch">
-{% endif %}
+{% endif -%}
 
 <!--[if IE]><link rel="shortcut icon" href="{{ asset_path('assets/images/favicon.ico') }}"><![endif]-->
 <!-- Touch Icons - iOS and Android 2.1+ 180x180 pixels in size. -->
 <link rel="apple-touch-icon" href="{{ asset_path('assets/images/apple-touch-icon.png') }}">
 <!-- Firefox, Chrome, Safari, IE 11+ and Opera. 192x192 pixels in size. -->
-{% if previewRevisionId %}
+{% if previewRevisionId -%}
   <link rel="icon" href="{{ asset_path('assets/images/favicon-preview.png') }}">
 {% else %}
   <link rel="icon" href="{{ asset_path('assets/images/favicon.png') }}">
-{% endif %}
+{% endif -%}
 
 <title>{{ title }}{{ ' - ' + meta.parent.title if meta.parent }} - NHS.UK</title>
-{% if description %}
+{% if description -%}
   <meta name="description" content="{{ description }}">
-{% endif %}
+{% endif -%}
 
 {# Webtrends journey tracking #}
 <meta name="WT.si_n" content="{{ meta.parent.title if meta.parent else title }}">
 <meta name="WT.si_p" content="{{ ORIGINAL_URL }}">
 
+<!-- opengraph -->
+<meta property="og:url" content="{{ CANONICAL_URL }}">
+<meta property="og:site_name" content="NHS.UK">
+<meta property="og:title" content="{{ title }}{{ ' - ' + meta.parent.title if meta.parent }} - NHS.UK">
+{% if description  -%}
+  <meta property="og:description" content="{{ description }}">
+{% endif -%}
+<meta property="og:type" content="website">
+<meta property="og:locale" content="en_GB">
 <meta property="og:image" content="{{ asset_path('assets/images/opengraph-image.png') }}">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="1200">
+
+<!-- twitter -->
+<meta name="twitter:card" value="summary">
+<meta name="twitter:domain" value="beta.nhs.uk">
+<meta name="twitter:title" content="{{ title }}{{ ' - ' + meta.parent.title if meta.parent }} - NHS.UK">
+{% if description  -%}
+  <meta name="twitter:description" content="{{ description }}">
+{% endif -%}
 
 {% if font %}
   <!--[if gt IE 8]><!--><link href="{{ asset_path('assets/stylesheets/nhsuk-' + font + '.css') }}" media="screen" rel="stylesheet" type="text/css"><!--<![endif]-->

--- a/config/express.js
+++ b/config/express.js
@@ -83,8 +83,6 @@ module.exports = (app, config) => {
     app.use(churchill(logger));
   }
 
-  app.use(locals(config));
-
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({
     extended: true,
@@ -95,6 +93,7 @@ module.exports = (app, config) => {
     trustProtoHeader: config.trustProtoHeader,
     trustAzureHeader: config.trustAzureHeader,
   }));
+  app.use(locals(config));
   app.use(assetPath(config, nunjucksEnv));
   app.use(feedback());
 

--- a/content/conditions/blisters/manifest.json
+++ b/content/conditions/blisters/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Blisters",
+  "description": "Blisters should heal on their own within a week. They can be painful while they heal, but you shouldn’t need to see a GP.",
   "nonEmergencyCallout": true,
   "choicesOrigin": "conditions/blisters/pages/introduction.aspx",
   "content": {

--- a/content/conditions/cold/manifest.json
+++ b/content/conditions/cold/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Common cold",
+  "description": "You can often treat a cold without seeing your GP. You should begin to feel better in about a week or two.",
   "nonEmergencyCallout": true,
   "choicesOrigin": "conditions/cold-common/pages/introduction.aspx",
   "content": {

--- a/content/conditions/constipation/manifest.json
+++ b/content/conditions/constipation/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Constipation",
+  "description": "Constipation is common and it affects people of all ages. You can usually treat it at home with simple changes to your diet and lifestyle.",
   "nonEmergencyCallout": false,
   "choicesOrigin": "conditions/constipation/pages/introduction.aspx",
   "content": {

--- a/content/conditions/dehydration/manifest.json
+++ b/content/conditions/dehydration/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Dehydration",
+  "description": "Dehydration means your body loses more fluids than you take in. This can affect your body but in most cases it’s nothing serious.",
   "nonEmergencyCallout": true,
   "choicesOrigin": "conditions/dehydration/pages/introduction.aspx",
   "content": {

--- a/content/conditions/diarrhoea/manifest.json
+++ b/content/conditions/diarrhoea/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Diarrhoea",
+  "description": "Diarrhoea usually goes away on it’s own within a few days. Make sure you or your child drink plenty of fluids.",
   "nonEmergencyCallout": false,
   "choicesOrigin": "Conditions/diarrhoea/Pages/Introduction.aspx",
   "content": {

--- a/content/conditions/earache/manifest.json
+++ b/content/conditions/earache/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Earache and pain",
+  "description": "Earache and pain is common, particularly in young children. It’s not usually a sign of anything serious, but it can be painful.",
   "nonEmergencyCallout": true,
   "choicesorigin": "conditions/earache/pages/introduction.aspx",
   "content": {

--- a/content/conditions/earwax/manifest.json
+++ b/content/conditions/earwax/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Earwax build-up",
+  "description": "Normally earwax just falls out on its own. When it’s blocking your ears a pharmacist can help.",
   "nonEmergencyCallout": false,
   "choicesOrigin": "conditions/earwax/pages/introduction.aspx",
   "content": {

--- a/content/conditions/flu/manifest.json
+++ b/content/conditions/flu/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Flu",
+  "description": "You can often treat the flu without seeing your GP and you should begin to feel better in about a week.",
   "nonEmergencyCallout": false,
   "choicesOrigin": "conditions/flu/pages/introduction.aspx",
   "content": {

--- a/content/conditions/fungal-nail-infection/manifest.json
+++ b/content/conditions/fungal-nail-infection/manifest.json
@@ -2,6 +2,7 @@
   "layout": "content-simple",
   "font": "frutiger",
   "title": "Fungal nail infection",
+  "description": "Fungal nail infections are common. They’re not serious but they can take a long time to treat.",
   "nonEmergencyCallout": false,
   "choicesOrigin": "conditions/fungal-nail-infection/pages/introduction.aspx",
   "content": {

--- a/content/conditions/hand-foot-and-mouth-disease/manifest.json
+++ b/content/conditions/hand-foot-and-mouth-disease/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Hand, foot and mouth disease",
+  "description": "Hand, foot and mouth disease is a common childhood illness that can affect adults. It usually clears up by itself in 7 to 10 days.",
   "nonEmergencyCallout": true,
   "choicesOrigin": "conditions/hand-foot-and-mouth-disease/pages/introduction.aspx",
   "content": {

--- a/content/conditions/hay-fever/manifest.json
+++ b/content/conditions/hay-fever/manifest.json
@@ -1,13 +1,14 @@
 {
   "layout": "content-simple",
   "title": "Hay fever",
+  "description": "Hay fever is usually worse between late March and September, especially when it’s warm, humid and windy. This is when the pollen count is at its highest.",
   "nonEmergencyCallout": false,
   "choicesorigin": "conditions/hay-fever/pages/introduction.aspx",
   "content": {
     "header": [
       {
         "type": "markdown",
-        "value": "Hay fever is usually worse between late March and September, especially when it’s warm, humid and windy. This is when the pollen count is at its highest. "
+        "value": "Hay fever is usually worse between late March and September, especially when it’s warm, humid and windy. This is when the pollen count is at its highest."
       }
     ],
     "main": [

--- a/content/conditions/head-lice/manifest.json
+++ b/content/conditions/head-lice/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Head lice and nits",
+  "description": "Head lice and nits are very common in young children. They don’t have anything to do with dirty hair, and are usually picked up by head-to-head contact.",
   "nonEmergencyCallout": false,
   "choicesOrigin": "conditions/head-lice/pages/introduction.aspx",
   "content": {

--- a/content/conditions/heat-exhaustion-and-heatstroke/manifest.json
+++ b/content/conditions/heat-exhaustion-and-heatstroke/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Heat exhaustion and heat stroke",
+  "description": "Heat exhaustion and heat stroke are serious if not treated quickly. You should give first aid and call 999 if you think there are signs of heat stroke.",
   "nonEmergencyCallout": false,
   "choicesOrigin": "Conditions/Heat-exhaustion-and-heatstroke/Pages/Introduction.aspx",
   "content": {

--- a/content/conditions/heat-rash/manifest.json
+++ b/content/conditions/heat-rash/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Heat rash (prickly heat)",
+  "description": "Heat rash is uncomfortable but usually harmless. It should clear up on its own after a few days.",
   "nonEmergencyCallout": true,
   "choicesOrigin": "conditions/prickly-heat/pages/introduction.aspx",
   "content": {

--- a/content/conditions/hernia/manifest.json
+++ b/content/conditions/hernia/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Hernia",
+  "description": "A hernia looks like a lump under the skin. It can be different sizes.",
   "nonEmergencyCallout": false,
   "choicesOrigin": "conditions/hernia/pages/introduction.aspx",
   "content": {

--- a/content/conditions/hernia/operation/manifest.json
+++ b/content/conditions/hernia/operation/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Hernia operation",
+  "description": "You’ll need an operation to fix a hernia. You may not need an operation straight away. Your hernia won’t get better without surgery, but it doesn’t always get worse. You can discuss with your doctor whether or not you need surgery.",
   "nonEmergencyCallout": false,
   "choicesOrigin": "conditions/hernia/pages/introduction.aspx",
   "content": {

--- a/content/conditions/hernia/types-of-hernia/manifest.json
+++ b/content/conditions/hernia/types-of-hernia/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "What is a hernia?",
+  "description": "A hernia happens when your bowel or fatty tissue pokes through a gap in the muscle. This is because of a weakness in your muscle. It can be something you’re born with or caused by a strain, such as straining on the toilet or being overweight.",
   "nonEmergencyCallout": false,
   "choicesOrigin": "conditions/hernia/pages/introduction.aspx",
   "content": {

--- a/content/conditions/hives/manifest.json
+++ b/content/conditions/hives/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Hives",
+  "description": "Hives rashes usually settle down within a few minutes to a few days. You can often treat hives yourself.",
   "nonEmergencyCallout": true,
   "choicesOrigin": "conditions/nettle-rash/pages/introduction.aspx",
   "content": {

--- a/content/conditions/indigestion/manifest.json
+++ b/content/conditions/indigestion/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Indigestion",
+  "description": "Most people have indigestion at some point. Usually, it's not a sign of anything more serious and you can treat indigestion yourself.",
   "nonEmergencyCallout": false,
   "choicesOrigin": "conditions/indigestion/pages/introduction.aspx",
   "content": {

--- a/content/conditions/insect-bites-and-stings/manifest.json
+++ b/content/conditions/insect-bites-and-stings/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Insect bites and stings",
+  "description": "Most insect bites and stings clear up on their own in a few hours or 2 to 3 days. You can usually treat them without seeing a GP.",
   "nonEmergencyCallout": false,
   "choicesOrigin": "conditions/bites-insect/pages/introduction.aspx",
   "content": {

--- a/content/conditions/mouth-ulcers/manifest.json
+++ b/content/conditions/mouth-ulcers/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Mouth ulcers",
+  "description": "Mouth ulcers are common and should clear up on their own within a week or two. They’re rarely a sign of anything serious, but may be uncomfortable to live with.",
   "nonEmergencyCallout": true,
   "choicesOrigin": "conditions/mouth-ulcers/pages/introduction.aspx",
   "content": {

--- a/content/conditions/nosebleed/manifest.json
+++ b/content/conditions/nosebleed/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Nosebleed",
+  "description": "Nosebleeds aren’t usually a sign of anything serious. They’re common, particularly in children, and most can be easily treated at home.",
   "nonEmergencyCallout": false,
   "choicesOrigin": "conditions/nosebleed/pages/introduction.aspx",
   "content": {

--- a/content/conditions/piles/manifest.json
+++ b/content/conditions/piles/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Piles (haemorrhoids)",
+  "description": "Piles (haemorrhoids) are swellings inside or around the bottom. They are common and often clear up on their own after a few days.",
   "nonEmergencyCallout": false,
   "choicesOrigin": "conditions/haemorrhoids/pages/introduction.aspx",
   "content": {

--- a/content/conditions/shingles/manifest.json
+++ b/content/conditions/shingles/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Shingles",
+  "description": "Usually you get shingles on your chest and tummy, but it can appear on your face, eyes and genitals.",
   "nonEmergencyCallout": false,
   "choicesOrigin": "conditions/shingles/pages/introduction.aspx",
   "content": {

--- a/content/conditions/sore-throat/manifest.json
+++ b/content/conditions/sore-throat/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Sore throat",
+  "description": "Sore throats are very common and usually nothing to worry about. They normally get better by themselves within a week.",
   "nonEmergencyCallout": false,
   "choicesOrigin": "conditions/sore-throat/pages/introduction.aspx",
   "content": {

--- a/content/conditions/sprains-and-strains/manifest.json
+++ b/content/conditions/sprains-and-strains/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Sprains and strains",
+  "description": "Sprains and strains are common injuries affecting the muscles and ligaments. Most can be treated at home without seeing a GP.",
   "nonEmergencyCallout": true,
   "choicesOrigin": "conditions/sprains/pages/introduction.aspx",
   "content": {

--- a/content/conditions/stye/manifest.json
+++ b/content/conditions/stye/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Stye",
+  "description": "Styes are common and should clear up on their own within a week or two. They’re rarely a sign of anything serious but may be painful until they heal.",
   "nonEmergencyCallout": true,
   "choicesOrigin": "conditions/stye/pages/introduction.aspx",
   "content": {

--- a/content/conditions/warts/manifest.json
+++ b/content/conditions/warts/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Warts and verrucas",
+  "description": "Warts and verrucas are small lumps on the skin that most people have at some point in their life. They usually go away on their own, but it can take months or even years.",
   "nonEmergencyCallout": false,
   "choicesOrigin": "conditions/warts/pages/introduction.aspx",
   "content": {

--- a/content/index/manifest.json
+++ b/content/index/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Test pages for NHS.UK",
+  "description": "This is where NHS.UK tests new pages and services to get feedback. Please take a look and tell us what you think. It will help us to improve what we do.",
   "content": {
     "main": [
       {

--- a/content/symptoms/headache/manifest.json
+++ b/content/symptoms/headache/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Headache",
+  "description": "Most headaches will go away on their own and aren’t a sign of something more serious.",
   "nonEmergencyCallout": true,
   "choicesOrigin": "conditions/headache/pages/introduction.aspx",
   "content": {

--- a/content/symptoms/rashes-in-babies-and-children/local-header.md
+++ b/content/symptoms/rashes-in-babies-and-children/local-header.md
@@ -1,1 +1,0 @@
-Many things can cause a rash in children and they’re often nothing to worry about.

--- a/content/symptoms/rashes-in-babies-and-children/manifest.json
+++ b/content/symptoms/rashes-in-babies-and-children/manifest.json
@@ -1,13 +1,14 @@
 {
   "layout": "content-simple",
   "title": "Rashes in babies and children",
+  "description": "Many things can cause a rash in children and they’re often nothing to worry about.",
   "nonEmergencyCallout": true,
   "choicesOrigin": "conditions/skin-rash-children/pages/introduction.aspx",
   "content": {
     "header": [
       {
         "type": "markdown",
-        "value": "!file=local-header.md"
+        "value": "Many things can cause a rash in children and they’re often nothing to worry about."
       },
       {
         "type": "section_nav"

--- a/content/symptoms/stomach-ache/manifest.json
+++ b/content/symptoms/stomach-ache/manifest.json
@@ -1,6 +1,7 @@
 {
   "layout": "content-simple",
   "title": "Stomach ache",
+  "description": "Most stomach aches aren’t anything serious and will go away after a few days.",
   "nonEmergencyCallout": true,
   "choicesOrigin": "conditions/stomach-ache-abdominal-pain/Pages/Introduction.aspx",
   "content": {


### PR DESCRIPTION
This change improves the meta data that is pulled in from other sources when a content item is shared.

Currently we don't provide any meta descriptions. This change also uses the short copy from the local header for page descriptions to give a better insight into the content of the page.

## How it looks

Once deployed the URL will reflect the production URL.

### Facebook

<img width="539" alt="screen shot 2017-01-19 at 17 23 36" src="https://cloud.githubusercontent.com/assets/3327997/22117693/d416ce18-de6c-11e6-8c29-724b103ba737.png">

### Twitter

<img width="451" alt="screen shot 2017-01-19 at 17 23 01" src="https://cloud.githubusercontent.com/assets/3327997/22117709/da0dab8e-de6c-11e6-9ac9-a0d4cee0e6a0.png">

### Slack

<img width="611" alt="screen shot 2017-01-19 at 17 24 11" src="https://cloud.githubusercontent.com/assets/3327997/22117716/dfcab134-de6c-11e6-9912-1c06af96aa00.png">

## Future

Slack and Twitter also support the addition of label:data pairs to provide extra information. Some examples can include the price of an item or its availability. It might be good to investigate if including supplementary data might help meet user needs for certain conditions. 

Possible things to include could be symptoms of a condition or when to see a GP/go to A&E.

One of the developers at Slack has written a [blog post](https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254#.n8shdmam5) about improving the _unfurling_ of pages. It includes some examples of good unfurls.