### PR TITLE
Update 111 callout consistency

### DIFF
--- a/content/conditions/constipation/main-content.md
+++ b/content/conditions/constipation/main-content.md
@@ -147,10 +147,6 @@ Different [types of laxatives](http://www.nhs.uk/conditions/Laxatives/Pages/Intr
   Speak to your doctor before you stop taking any prescribed medication.
 !!!
 
-!!! info_compact
-  If you’re not sure what to do, call 111.
-!!!
-
 ## Complications of long-term constipation
 
 Long-term constipation can lead to faecal impaction. This is where poo has built up in your rectum.

--- a/content/conditions/constipation/manifest.json
+++ b/content/conditions/constipation/manifest.json
@@ -2,7 +2,7 @@
   "layout": "content-simple",
   "title": "Constipation",
   "description": "Constipation is common and it affects people of all ages. You can usually treat it at home with simple changes to your diet and lifestyle.",
-  "nonEmergencyCallout": false,
+  "nonEmergencyCallout": true,
   "choicesOrigin": "conditions/constipation/pages/introduction.aspx",
   "content": {
     "header": [

--- a/content/conditions/heat-exhaustion-and-heatstroke/main-content.md
+++ b/content/conditions/heat-exhaustion-and-heatstroke/main-content.md
@@ -40,10 +40,6 @@ Stay with them until they are better.
 
 They should start to cool down and feel better within 30 minutes.
 
-!!! info_compact
-  If you’re not sure what to do call 111.
-!!!
-
 !!! severe
   ## Call 999 if the person:
 

--- a/content/conditions/heat-exhaustion-and-heatstroke/manifest.json
+++ b/content/conditions/heat-exhaustion-and-heatstroke/manifest.json
@@ -2,7 +2,7 @@
   "layout": "content-simple",
   "title": "Heat exhaustion and heat stroke",
   "description": "Heat exhaustion and heat stroke are serious if not treated quickly. You should give first aid and call 999 if you think there are signs of heat stroke.",
-  "nonEmergencyCallout": false,
+  "nonEmergencyCallout": true,
   "choicesOrigin": "Conditions/Heat-exhaustion-and-heatstroke/Pages/Introduction.aspx",
   "content": {
     "header": [


### PR DESCRIPTION
Currently we use the 111 callout at the foot of the content. These two
content items embed that content in the page. We are going to do an
overall review of the placement of the 111 banner but for now we should
be consistent in our use of it.