### PR TITLE
Add ability to show development routes if NODE_ENV=production

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ environment.
 | `NODE_ENV`                         | node environment                                                                                                                       | development              |
 | `PORT`                             | server port                                                                                                                            | 3000                     |
 | `GOOGLE_ANALYTICS_TRACKING_ID`     | Google Analytics property id                                                                                                           |                          |
+| `SHOW_DEVELOPMENT_ROUTES`          | Will show development only routes in a production environment if `true` | false |
 | `WEBTRENDS_TRACKING_ID`            | [Webtrends](https://www.webtrends.com/) tracking id                                                                                    |                          |
 | `HOTJAR_TRACKING_ID`               | [Hotjar](https://www.hotjar.com/) tracking id                                                                                          |                          |
 | `FONT_CDN`                         | Base url where the font is served                                                                                                      | /                        |

--- a/app/middleware/development.js
+++ b/app/middleware/development.js
@@ -1,7 +1,7 @@
 const config = require('../../config/config');
 
 module.exports = (req, res, next) => {
-  if (config.env !== 'development') {
+  if (config.env !== 'development' && !config.showDevelopmentRoutes) {
     const err = new Error('Page not found');
     err.status = 404;
     return next(err);

--- a/config/config.js
+++ b/config/config.js
@@ -9,6 +9,7 @@ module.exports = {
   env: process.env.NODE_ENV || 'development',
   ci: process.env.CI,
   port,
+  showDevelopmentRoutes: process.env.SHOW_DEVELOPMENT_ROUTES || false,
   googleAnalyticsId: process.env.GOOGLE_ANALYTICS_TRACKING_ID,
   webtrendsId: process.env.WEBTRENDS_TRACKING_ID,
   hotjarId: process.env.HOTJAR_TRACKING_ID,


### PR DESCRIPTION
This change allows an variable to be set on the environment to display routes that by default we don't want available. For example, a view showing all the elements or components.