### PR TITLE
Improve consistency of content patterns

### DIFF
--- a/content/conditions/cough/manifest.json
+++ b/content/conditions/cough/manifest.json
@@ -48,7 +48,7 @@
       {
         "type": "callout",
         "props": {
-          "variant": "alert",
+          "variant": "attention",
           "children": [
             {
               "type": "text",

--- a/content/conditions/dehydration/callout-emergency.md
+++ b/content/conditions/dehydration/callout-emergency.md
@@ -7,7 +7,6 @@
 - your pulse is weak or rapid
 - you have fits (seizures)
 
-***
 These can be signs of serious dehydration which needs urgent treatment.
 
 *[A&E]: Accident and Emergency

--- a/content/conditions/diarrhoea/callout-gp-babies.md
+++ b/content/conditions/diarrhoea/callout-gp-babies.md
@@ -7,5 +7,4 @@
 - have severe stomach ache or one that doesn’t stop
 - still have diarrhoea after 5 to 7 days
 
-***
 Diarrhoea can be infectious. Check with your GP before you go in. They may suggest a phone consultation.

--- a/content/conditions/diarrhoea/callout-gp.md
+++ b/content/conditions/diarrhoea/callout-gp.md
@@ -6,5 +6,4 @@
 - the diarrhoea doesn’t go away
 - you have recently taken antibiotics or been treated in hospital
 
-***
 Diarrhoea can be infectious. Check with your GP before you go in. They may suggest a phone consultation.

--- a/content/conditions/diarrhoea/callout-urgent-babies.md
+++ b/content/conditions/diarrhoea/callout-urgent-babies.md
@@ -5,7 +5,6 @@
 - have severe tummy pain
 - are getting worse quickly
 
-***
 If you can’t get hold of your GP, go to A&E.
 
 *[A&E]: Accident and Emergency

--- a/content/conditions/earache/callout-gp.md
+++ b/content/conditions/earache/callout-gp.md
@@ -8,5 +8,4 @@
 - hearing loss or a change in hearing
 - other symptoms, like vomiting or a severe sore throat
 
-***
 If you can’t get an appointment, contact 111 or go to a [walk-in centre](http://www.nhs.uk/Service-Search/Walk-in%20centre/LocationSearch/663).

--- a/content/conditions/hand-foot-and-mouth-disease/callout-gp.md
+++ b/content/conditions/hand-foot-and-mouth-disease/callout-gp.md
@@ -5,5 +5,6 @@
 - you’re worried about your child’s symptoms
 - your child is dehydrated - they’re not peeing as often as usual
 - you’re pregnant and get hand, foot and mouth disease
----
-Hand, foot and mouth disease is infectious. Check with your GP surgery before you go in. They may suggest a phone consultation.
+
+Hand, foot and mouth disease is infectious. Check with your GP surgery before
+you go in. They may suggest a phone consultation.

--- a/content/conditions/heat-exhaustion-and-heatstroke/callout-emergency.md
+++ b/content/conditions/heat-exhaustion-and-heatstroke/callout-emergency.md
@@ -9,8 +9,9 @@
 - loses consciousness
 - is unresponsive
 
----
 These can be signs of heat stroke.
+
+***
 
 While you wait for help, keep giving first aid and
 [put them in the recovery position if they lose consciousness](http://www.nhs.uk/Conditions/Accidents-and-first-aid/Pages/The-recovery-position.aspx).

--- a/content/conditions/hives/callout-emergency.md
+++ b/content/conditions/hives/callout-emergency.md
@@ -7,7 +7,6 @@
 - an increased heart rate
 - rapid and severe swelling of the face, mouth or throat
 
-***
 These could be signs of a severe allergic reaction such as [anaphylactic shock](http://www.nhs.uk/conditions/Anaphylaxis/Pages/Introduction.aspx).
 
 *[A&E]: Accident and Emergency

--- a/content/conditions/indigestion/callout-gp.md
+++ b/content/conditions/indigestion/callout-gp.md
@@ -9,3 +9,5 @@
 - have iron deficiency anaemia
 - feel like you have a lump in your stomach
 - have bloody vomit or poo
+
+These symptoms can be a sign of something more serious.

--- a/content/conditions/indigestion/main-content-3.md
+++ b/content/conditions/indigestion/main-content-3.md
@@ -1,5 +1,3 @@
-These symptoms can be a sign of something more serious.
-
 ## Indigestion, heartburn and acid reflux - what’s the difference?
 
 Heartburn and acid reflux are the same thing. It’s when acid from your stomach comes up your throat.

--- a/content/conditions/insect-bites-and-stings/callout-emergency.md
+++ b/content/conditions/insect-bites-and-stings/callout-emergency.md
@@ -7,7 +7,6 @@
 - an increased heart rate
 - rapid and severe swelling of the face, mouth or throat
 
-***
 These could be signs of a severe allergic reaction such as [anaphylactic shock](http://www.nhs.uk/conditions/Anaphylaxis/Pages/Introduction.aspx).
 
 *[A&E]: Accident and Emergency

--- a/content/conditions/mouth-ulcers/callout-gp.md
+++ b/content/conditions/mouth-ulcers/callout-gp.md
@@ -4,6 +4,5 @@
 - keeps coming back
 - becomes more painful and red - this may be a sign of an infection
 
-***
-
-Although most mouth ulcers are harmless, a long-lasting mouth ulcer is sometimes a sign of mouth cancer. It’s best to get it checked.
+Although most mouth ulcers are harmless, a long-lasting mouth ulcer is
+sometimes a sign of mouth cancer. It’s best to get it checked.

--- a/content/conditions/sore-throat/callout-emergency.md
+++ b/content/conditions/sore-throat/callout-emergency.md
@@ -5,7 +5,6 @@
 - your voice changes pitch or becomes wheezy
 - your symptoms are severe and getting worse quickly
 
-***
 These symptoms can make breathing more difficult.
 
 *[A&E]: Accident and Emergency

--- a/content/conditions/sprains-and-strains/callout-emergency.md
+++ b/content/conditions/sprains-and-strains/callout-emergency.md
@@ -5,8 +5,6 @@
 - the injured body part has changed shape
 - you feel dizzy or sick
 
-***
-
 You may have broken a bone and will need an X-ray.
 
 *[A&E]: Accident and Emergency

--- a/content/conditions/sprains-and-strains/callout-gp.md
+++ b/content/conditions/sprains-and-strains/callout-gp.md
@@ -4,7 +4,3 @@
 - you’re still in a lot of pain and can’t put weight on the injured joint
 - you can’t move the joint or muscle
 - the injury is numb, discoloured or cold to touch
-
-***
-
-[Find a minor injuries unit](http://www.nhs.uk/service-search/Minor-injuries-unit/LocationSearch/551)

--- a/content/conditions/sprains-and-strains/callout-service-link-3.md
+++ b/content/conditions/sprains-and-strains/callout-service-link-3.md
@@ -1,0 +1,1 @@
+[Find a minor injuries unit](http://www.nhs.uk/service-search/Minor-injuries-unit/LocationSearch/551)

--- a/content/conditions/sprains-and-strains/manifest.json
+++ b/content/conditions/sprains-and-strains/manifest.json
@@ -84,6 +84,22 @@
         }
       },
       {
+        "type": "callout",
+        "props": {
+          "variant": "info",
+          "compact": true,
+          "children": [
+            {
+              "type": "text",
+              "props": {
+                "variant": "markdown",
+                "value": "!file=callout-service-link-3.md"
+              }
+            }
+          ]
+        }
+      },
+      {
         "type": "text",
         "props": {
           "variant": "markdown",

--- a/content/conditions/warts/callout-gp.md
+++ b/content/conditions/warts/callout-gp.md
@@ -6,8 +6,5 @@
 - a wart bleeds or changes how it looks
 - you have a wart on your face or genitals
 
-***
 [Genital warts](http://www.nhs.uk/Conditions/Genital_warts/Pages/Introduction.aspx) can also be treated at
 a sexual health or GUM clinic.
-
-[Find your nearest sexual health service](http://www.nhs.uk/Service-Search/Sexual%20health%20services/LocationSearch/1847)

--- a/content/conditions/warts/callout-service-link.md
+++ b/content/conditions/warts/callout-service-link.md
@@ -1,0 +1,1 @@
+[Find your nearest sexual health service](http://www.nhs.uk/Service-Search/Sexual%20health%20services/LocationSearch/1847)

--- a/content/conditions/warts/manifest.json
+++ b/content/conditions/warts/manifest.json
@@ -96,6 +96,22 @@
         }
       },
       {
+        "type": "callout",
+        "props": {
+          "variant": "info",
+          "compact": true,
+          "children": [
+            {
+              "type": "text",
+              "props": {
+                "variant": "markdown",
+                "value": "!file=callout-service-link.md"
+              }
+            }
+          ]
+        }
+      },
+      {
         "type": "text",
         "props": {
           "variant": "markdown",


### PR DESCRIPTION
We've used horizontal rules (`hr`) where they don't semantically make
sense.

This change improves the use of hr's across the beta content pages.