### PR TITLE
Update hidden text component

### DIFF
--- a/app/views/_components/reveal.nunjucks
+++ b/app/views/_components/reveal.nunjucks
@@ -24,7 +24,7 @@
     <span class="details__summary">{{ summary }}</span>
   </summary>
 
-  <div>
+  <div class="details__content">
     {% for component in children %}
       {% component name=component.type, context=component.props %}
     {% endfor %}

--- a/assets/stylesheets/units/_details.scss
+++ b/assets/stylesheets/units/_details.scss
@@ -64,6 +64,18 @@ details {
   text-decoration: underline;
 }
 
+.details__content {
+  @include element-padding(left);
+  border-left: $baseline-grid-unit * 2 solid $grey-3;
+  padding-bottom: $baseline-grid-unit * 2;
+  padding-top: $baseline-grid-unit * 2;
+
+  @include media(desktop) {
+    padding-bottom: $baseline-grid-unit * 4;
+    padding-top: $baseline-grid-unit * 4;
+  }
+}
+
 .details--inline {
   summary {
     color: $black;

--- a/assets/stylesheets/units/_tables.scss
+++ b/assets/stylesheets/units/_tables.scss
@@ -1,7 +1,6 @@
 table {
   border-collapse: collapse;
   border-spacing: 0;
-  margin: ($baseline-grid-unit * 4) 0 ($baseline-grid-unit * 8);
   width: 100%;
 
   th,
@@ -14,6 +13,7 @@ table {
 
   th {
     @include bold-font(20);
+    padding-top: 0;
     text-align: left;
   }
 }

--- a/test/unit/components/reveal.test.js
+++ b/test/unit/components/reveal.test.js
@@ -15,7 +15,7 @@ describe('Reveal component', () => {
           <span class="details__summary">Summary text</span>
         </summary>
 
-        <div>
+        <div class="details__content">
         </div>
       </details>
       `
@@ -36,7 +36,7 @@ describe('Reveal component', () => {
           <span class="details__summary">Summary text with <span class="details__cta">inline link</span></span>
         </summary>
 
-        <div>
+        <div class="details__content">
         </div>
       </details>
       `


### PR DESCRIPTION
This adds an indentation and left border to distinguish text
that has been revealed.

## Before

<img width="537" alt="screen shot 2017-03-08 at 10 43 46" src="https://cloud.githubusercontent.com/assets/3327997/23700863/3f9e7132-03ec-11e7-9da9-93a9bf18cef0.png">

<img width="531" alt="screen shot 2017-03-08 at 11 00 57" src="https://cloud.githubusercontent.com/assets/3327997/23701420/90e4d23c-03ee-11e7-938e-d8e2ed462bb4.png">

## After

<img width="535" alt="screen shot 2017-03-08 at 10 44 22" src="https://cloud.githubusercontent.com/assets/3327997/23700872/4554bdca-03ec-11e7-84bc-41f0523c23ef.png">

<img width="534" alt="screen shot 2017-03-08 at 11 00 32" src="https://cloud.githubusercontent.com/assets/3327997/23701428/9a67786e-03ee-11e7-9962-e5e3d16acd8b.png">


## Potential problems

### Images

**[EDIT]:** This is no longer an issue after the changes made in #334.

The image cards now stack when this extra padding is included. This could potentially be addressed by an alternative way of removing the images from the reveal and using a different method to hide/show more graphic images. We have discussed using a blur and an action to reveal the image.

<img width="331" alt="screen shot 2017-03-08 at 10 28 47" src="https://cloud.githubusercontent.com/assets/3327997/23700919/7e4c8d38-03ec-11e7-9248-d11612fc8d90.png">

### Inside binary lists

The more we nest content the less readable it seems to become. Maybe an alternative is to review the use of the side by side lists when they have large amounts of content and a reveal like this.

<img width="335" alt="screen shot 2017-03-08 at 10 28 29" src="https://cloud.githubusercontent.com/assets/3327997/23700947/9f979410-03ec-11e7-8fee-c69b0a472935.png">
